### PR TITLE
employees: cache and display photos when available

### DIFF
--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -10,6 +10,7 @@ class Employee < ApplicationRecord
   # Given an Net::LDAP::Entry extract and populate an Employee record
   # using the cn/uid as the unique key
   # @param [Net::LDAP::Entry] employee_info
+  # rubocop:disable Metrics/AbcSize
   def self.populate_from_ldap(employee_info)
     e = find_or_initialize_by(uid: employee_info.cn.first)
     e.display_name = employee_info.displayname.first
@@ -17,5 +18,17 @@ class Employee < ApplicationRecord
     e.manager = employee_info.manager.first
     e.name = "#{employee_info.givenName.first} #{employee_info.sn.first}"
     e.save
+    # try saving thumbnail as well
+    cache_employee_photo(employee_info)
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  # Given an Net::LDAP::Entry store the employee photo if available
+  # @param [Net::LDAP::Entry] employee_info
+  def self.cache_employee_photo(employee_info)
+    return unless employee_info.respond_to?(:thumbnailphoto)
+
+    image_path = Rails.root.join('app', 'assets', 'images', 'photos', "#{employee_info.cn.first}.jpg")
+    IO.write(image_path.to_s, employee_info.thumbnailphoto.first, mode: 'wb')
   end
 end

--- a/app/services/ldap/queries.rb
+++ b/app/services/ldap/queries.rb
@@ -35,7 +35,7 @@ module Ldap
       ldap_connection.search(
         filter: Ldap::Filters.employees,
         return_result: false,
-        attributes: %w[DisplayName CN mail manager givenName sn]
+        attributes: %w[DisplayName CN mail manager givenName sn Thumbnailphoto]
       ) do |employee|
         Employee.populate_from_ldap(employee)
       end

--- a/app/views/recognitions/index.html.erb
+++ b/app/views/recognitions/index.html.erb
@@ -10,7 +10,7 @@
 <table class='table'>
   <thead class="thead-light">
     <tr>
-      <th scope="col">Recognizee</th>
+      <th scope="col" colspan=2>Recognizee</th>
       <th scope="col">Library value</th>
       <th scope="col">Description</th>
       <th scope="col">Anonymous</th>
@@ -23,6 +23,11 @@
     <% @recognitions.each do |recognition| %>
       <tr>
         <td><%= recognition.employee.display_name %></td>
+        <% if(File.file?("app/assets/images/photos/#{recognition.employee.uid}.jpg")) %>
+        <td><%= image_tag("photos/#{recognition.employee.uid}.jpg") %></td>
+        <% else %>
+        <td></td>
+        <% end %>
         <td><%= recognition.library_value %></td>
         <td><%= recognition.description %></td>
         <td><%= recognition.anonymous ? 'Anonymous' : 'No' %></td>

--- a/app/views/recognitions/show.html.erb
+++ b/app/views/recognitions/show.html.erb
@@ -1,5 +1,8 @@
 <p id="notice"><%= notice %></p>
 
+<% if(File.file?("app/assets/images/photos/#{@recognition.employee.uid}.jpg")) %>
+<p><%= image_tag("photos/#{@recognition.employee.uid}.jpg") %></p>
+<% end %>
 <p>
   <strong>Recognizee:</strong>
   <%= @recognition.employee.display_name %>

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -36,4 +36,33 @@ RSpec.describe Employee, type: :model do
       expect(Employee.first.display_name).to eq('Batman')
     end
   end
+
+  describe '.cache_employee_photo' do
+    let(:entry1) { Net::LDAP::Entry.new('CN=aemployee,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU') }
+    before do
+      entry1['cn'] = 'aemployee'
+      entry1['displayName'] = ['Employee, A']
+      entry1['givenName'] = ['A']
+      entry1['sn'] = ['Employee']
+      entry1['mail'] = ['aemployee@ucsd.edu']
+      entry1['manager'] = ['boss1@ucsd.edu']
+    end
+    context 'without an ldap photo' do
+      it 'should not write to photos directory' do
+        expect(described_class.cache_employee_photo(entry1)).to be_nil
+      end
+    end
+
+    context 'with an ldap photo' do
+      after do
+        system("rm -rf #{Rails.root}/app/assets/images/photos/aemployee.jpg")
+      end
+      it 'should write to photos directory' do
+        entry1['Thumbnailphoto'] = '/9j/4AAQSkZJRgABAQEAAQABAAD//2gAIAQEAAD8AVN//2Q=='
+        described_class.cache_employee_photo(entry1)
+        expect(File.file?("#{Rails.root}/app/assets/images/photos/aemployee.jpg")).to be true
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
Fixes #40 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?

#### What does this PR do?

This PR adds very basic initial support for caching employee photos for display when they're recognized. It doesn't handle:

- Making it actually look nice
- Having a fallback icon/image when none is present
- Checking if an image already exists and determining whether to write over it or not. Because of how small these are, I'm currently assuming we always want the latest and greatest, but perhaps we could be smarter about this. thoughts?

##### Why are we doing this? Any context of related work?
References #40 

#### Where should a reviewer start?
Hopefully this is small enough to look through at the Employee model updates and related tests.

@ucsdlib/developers - please review
