### PR TITLE
Docker headless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,72 @@
-FROM ruby:2.5.3-alpine
+FROM ruby:2.5.3
 
-RUN apk --no-cache upgrade && \
-  apk add --no-cache \
-  build-base \
-  chromium-chromedriver \
-  chromium \
-  postgresql \
-  postgresql-dev \
-  nodejs \
-  nodejs-npm \
-  tzdata
+# Install current nodejs
+# gpg keys listed at https://github.com/nodejs/node#release-team
+RUN set -ex \
+  && for key in \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    56730D5401028683275BD23C23EFEFE93C4CFFFE \
+    77984A986EBC2AA786BC0F66B01FBB92821C587A \
+    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+  ; do \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done
 
+ENV NODE_VERSION 8.12.0
 
-RUN addgroup -g 1000 -S theodor && \
-    adduser -u 1000 -S theodor -G theodor
-USER theodor
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    ppc64el) ARCH='ppc64le';; \
+    s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
+    i386) ARCH='x86';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-RUN mkdir /home/theodor/app
-WORKDIR /home/theodor/app
-COPY --chown=theodor:theodor Gemfile* /home/theodor/app/
+# Install Chrome
+RUN set -ex \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" \
+        >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update -qqy \
+    && apt-get -qqy install google-chrome-stable unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Chromedriver
+ARG CHROME_DRIVER_VERSION="latest"
+RUN CD_VERSION=$(if [ ${CHROME_DRIVER_VERSION:-latest} = "latest" ]; then echo $(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE); else echo $CHROME_DRIVER_VERSION; fi) \
+  && echo "Using chromedriver version: "$CD_VERSION \
+  && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CD_VERSION/chromedriver_linux64.zip \
+  && rm -rf /opt/selenium/chromedriver \
+  && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium \
+  && rm /tmp/chromedriver_linux64.zip \
+  && mv /opt/selenium/chromedriver /opt/selenium/chromedriver-$CD_VERSION \
+  && chmod 755 /opt/selenium/chromedriver-$CD_VERSION \
+  && ln -fs /opt/selenium/chromedriver-$CD_VERSION /usr/bin/chromedriver
+
+ENV BUNDLE_PATH=/bundle \
+    BUNDLE_BIN=/bundle/bin \
+    GEM_HOME=/bundle
+ENV PATH="${BUNDLE_BIN}:${PATH}"
+
+RUN mkdir -p /app
+WORKDIR /app
+COPY Gemfile* ./
 RUN bundle install --jobs 4 --retry 3
-COPY --chown=theodor:theodor . /home/theodor/app/
+COPY . ./

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,21 @@
+FROM ruby:2.5.3-alpine
+
+RUN apk --no-cache upgrade && \
+  apk add --no-cache \
+  build-base \
+  postgresql \
+  postgresql-dev \
+  nodejs \
+  nodejs-npm \
+  tzdata
+
+
+RUN addgroup -g 1000 -S theodor && \
+    adduser -u 1000 -S theodor -G theodor
+USER theodor
+
+RUN mkdir /home/theodor/app
+WORKDIR /home/theodor/app
+COPY --chown=theodor:theodor Gemfile* /home/theodor/app/
+RUN bundle install --jobs 4 --retry 3
+COPY --chown=theodor:theodor . /home/theodor/app/

--- a/README.md
+++ b/README.md
@@ -19,18 +19,17 @@ To edit secrets: `bin/rails credentials:edit`
 1. Install docker and docker-compose
 1. Run docker-compose file `docker-compose up`
 
-**note** at the moment, the Chromium/Chromedriver versions on Alpine linux will
-not work with Capybara. So for now, run the application locally, and the
-docker-compose file will just run the database in a container.
-1. In a separate tab, setup the db `bin/rails db:create db:migrate`
+#### Testing
+1. Run tests with `docker-compose exec web` prefix for any RSpec command.
 
-OR (if you would like to pre-load Employee table for local dev)
-1. In a separate tab, setup the db `bin/rails db:setup`
-
-**when Alpine available again**
-1. In a separate tab, setup the db `docker-compose exec web bin/rails db:create db:migrate`
-OR (if you would like to pre-load Employee table for local dev)
-1. In a separate tab, setup the db `docker-compose exec web bin/rails db:setup`
+Examples:
+```
+docker-compose exec web bin/rails spec
+docker-compose exec web bundle exec rake spec
+docker-compose exec web bundle exec rake spec/models/user.rb
+docker-compose exec web bundle exec rake spec/models/user.rb:50
+...
+```
 
 #### Debugging
 With docker-compose running, in a new terminal/tab attach to the container:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,20 @@
 version: '3.6'
 
 services:
-#  web:
-#    build: .
-#    ports:
-#      - "3000:3000"
-#    working_dir: /home/theodor/app
-#    command: bundle exec puma
-#    volumes:
-#      - ./:/home/theodor/app
-#    depends_on:
-#      - database
-#    environment:
-#      DATABASE_URL: postgres://postgres@database
-#    stdin_open: true
-#    tty: true
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+    working_dir: /app
+    command: sh -c 'bin/rails db:drop db:create db:migrate && bundle exec puma'
+    volumes:
+      - ./:/app
+    depends_on:
+      - database
+    environment:
+      DATABASE_URL: postgres://postgres@database
+    stdin_open: true
+    tty: true
 
   database:
     image: postgres:10.5-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "3000:3000"
     working_dir: /app
-    command: sh -c 'bin/rails db:drop db:create db:migrate && bundle exec puma'
+    command: sh -c 'bin/rails db:create db:migrate && bundle exec puma'
     volumes:
       - ./:/app
     depends_on:

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe User, type: :model do
     info: { 'email' => 'test@ucsd.edu', 'name' => 'Dr. Seuss' }
   })}
 
-  let(:invalid_auth_hash) { OmniAuth::AuthHash.new({
-    info: { 'email' => 'test@ucsd.edu', 'name' => 'Dr. Seuss' }
+  let(:invalid_auth_hash_missing_info) { OmniAuth::AuthHash.new({
+    provider: 'shibboleth',
+    uid: 'test'
   })}
 
   describe ".find_or_create_for_developer" do
@@ -44,7 +45,7 @@ RSpec.describe User, type: :model do
     end
 
     it 'should throw an error with bad or missing response information' do
-      expect { User.find_or_create_for_shibboleth(invalid_auth_hash) }.to raise_error(StandardError)
+      expect { User.find_or_create_for_shibboleth(invalid_auth_hash_missing_info) }.to raise_error(StandardError)
     end
   end
 

--- a/spec/support/capybara_selenium.rb
+++ b/spec/support/capybara_selenium.rb
@@ -4,7 +4,25 @@ require 'selenium-webdriver'
 
 Capybara.server = :puma, { Silent: true }
 
-Capybara.javascript_driver = :selenium_chrome_headless
+Capybara.register_driver :chrome_headless do |app|
+  options = ::Selenium::WebDriver::Chrome::Options.new
+
+  options.add_argument('--headless')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
+  options.add_argument('--window-size=1400,1400')
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+if ENV["CIRCLECI"] == true
+  Capybara.javascript_driver = :selenium_chrome_headless
+else
+  Capybara.javascript_driver = :chrome_headless
+end
+
+Capybara.javascript_driver = :chrome_headless
+
 Capybara.default_max_wait_time = 5
 
 RSpec.configure do |config|
@@ -12,6 +30,10 @@ RSpec.configure do |config|
     driven_by :rack_test
   end
   config.before(:each, type: :system, js: true) do
+  if ENV["CIRCLECI"] == true
     driven_by :selenium_chrome_headless
+  else
+    driven_by :chrome_headless
+  end
   end
 end


### PR DESCRIPTION
Fixes #59 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [x] Configuration updated (if needed)?
- [x] Documentation updated (if needed)?

#### What does this PR do?
Add full docker-compose support for running the app with javascript tests, which require a modern version of nodejs, chrome(ium) and chromedriver. Moves away from using an Alpine base, which is a bit sad since the container will be much larger now, but it works.

##### Why are we doing this? Any context of related work?
References #59 

#### Manual testing steps?
1. Pull down this branch
1. Remove containers `docker-compose rm -v`
1. build new containers `docker-compose build`
1. run compose `docker-compose up`
1. run test suite `docker-compose exec web bundle exec rake spec`

#### New ENV variables

Now leveraging `CIRCLECI` to test if we're in that context for setting the capybara driver.

@VivianChu - please review