### PR TITLE
bundle: remove chromedriver-helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,6 @@ group :development, :test do
   gem "simplecov", require: false
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'capybara'
-  gem 'chromedriver-helper'
   gem 'coveralls'
   gem 'factory_bot_rails'
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,8 +44,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     autoprefixer-rails (9.1.4)
@@ -69,9 +67,6 @@ GEM
       xpath (~> 3.2)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (2.1.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     chronic (0.10.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -103,7 +98,6 @@ GEM
     hashie (3.5.7)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jaro_winkler (1.5.1)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -280,7 +274,6 @@ DEPENDENCIES
   bootstrap (~> 4.1.3)
   byebug
   capybara
-  chromedriver-helper
   coffee-rails (~> 4.2)
   coveralls
   factory_bot_rails


### PR DESCRIPTION
This gem shouldn't be necessary anymore since chromedriver is installed an run within the context of the container via docker and docker-compose.