### PR TITLE
form: clarify anonymous submission for users

### DIFF
--- a/app/views/recognitions/_form.html.erb
+++ b/app/views/recognitions/_form.html.erb
@@ -9,7 +9,9 @@
 
   <%= f.input :description %>
 
-  <%= f.input :anonymous %>
+  <%= f.input :anonymous,
+              label: 'Please do not include my name with the post',
+              hint: 'Your name will still be shared with the person being recognized and their supervisor'%>
 
   <%= f.button :submit, class: "btn-primary" %>
 <% end %>


### PR DESCRIPTION
Fixes #71 

#### Local Checklist
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?

#### What does this PR do?
Adds a label and hint clarifying to the user what an anonymous submission means. This was ported from the original Mach Form and only tweaked slightly for context (this is not a blog) and gender pronouns.

##### Why are we doing this? Any context of related work?
References #71 

#### Screenshots
![anonymous_info](https://user-images.githubusercontent.com/67506/48147534-64c86480-e26c-11e8-87aa-c5d79b870d57.png)

#### Deployment Instructions

@VivianChu - please review
