### PR TITLE
docker: update nodejs to latest 10.x version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN set -ex \
     gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV NODE_VERSION 8.12.0
+ENV NODE_VERSION 10.13.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \


### PR DESCRIPTION
Fixes #62 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?

#### What does this PR do?
Updates the version of NodeJS installed into the Dockerfile to the latest 10.x version (10.13.0)

##### Why are we doing this? Any context of related work?
References #62 

Version 10 is an LTS branch for NodeJS, so we're safe updating to this for the foreseeable future.

#### Manual testing steps?
Rebuild your docker image and run the tests, the app, etc. and make sure things work. All seemed fine to me other than an install warning about a GPG key signature reported in https://github.com/nodejs/node/issues/23992 which should fix itself up once the person gets their subkey updated and pushed through gpg mirrors. I'll keep an eye on it.

@VivianChu  - please review
