### PR TITLE
Add initial statistics support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 # Ignore coverage
 /coverage
 
+# Ignore employee photos
+/app/assets/images/photos/*.jpg
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'omniauth-shibboleth'
 #
 # Simple Form, Bootstrap and friends
 gem 'bootstrap', '~> 4.1.3'
+gem 'bootstrap-datepicker-rails'
 gem 'jquery-rails'
 gem 'simple_form'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,8 @@ GEM
       autoprefixer-rails (>= 6.0.3)
       popper_js (>= 1.12.9, < 2)
       sass (>= 3.5.2)
+    bootstrap-datepicker-rails (1.8.0.1)
+      railties (>= 3.0)
     builder (3.2.3)
     byebug (10.0.2)
     capybara (3.10.1)
@@ -272,6 +274,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.1.3)
+  bootstrap-datepicker-rails
   byebug
   capybara
   coffee-rails (~> 4.2)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,4 +16,5 @@
 //= require jquery3
 //= require popper
 //= require bootstrap
+//= require bootstrap-datepicker
 //= require_tree .

--- a/app/assets/javascripts/statistics.js
+++ b/app/assets/javascripts/statistics.js
@@ -1,0 +1,6 @@
+// Setup datepicker for statistics query
+$(document).ready(function(){
+  $('.input-daterange').datepicker({
+    format: "yyyy-mm-dd"
+  });
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,3 @@
 // Custom bootstrap variables must be set or imported *before* bootstrap.
 @import "bootstrap";
+@import "bootstrap-datepicker";

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# StatisticsController
+class StatisticsController < ApplicationController
+  include StatisticsHelper
+  before_action :require_administrator, only: %i[index]
+
+  # GET /statistics
+  def index
+    return unless params[:start_date] && params[:end_date]
+
+    start_date = statistics_params[:start_date]
+    end_date = statistics_params[:end_date]
+    results = Recognition.created_between(start_date, end_date)
+
+    if results.empty?
+      flash[:notice] = 'There were no records matching your date range'
+    else
+      send_data generate_csv(results), filename: "highfive-stats-#{start_date}-#{end_date}.csv"
+    end
+  end
+
+  private
+
+  def statistics_params
+    params.permit(:start_date, :end_date)
+  end
+end

--- a/app/helpers/auth_helper.rb
+++ b/app/helpers/auth_helper.rb
@@ -20,7 +20,6 @@ module AuthHelper
 
   # Require that a current user is authenticated and an administrator
   def require_administrator
-    # redirect_to recognitions_path unless logged_in?# && User.administrator?(current_user)
     redirect_to recognitions_path unless logged_in? && valid_administrator?
   end
 end

--- a/app/helpers/auth_helper.rb
+++ b/app/helpers/auth_helper.rb
@@ -13,4 +13,11 @@ module AuthHelper
   def logged_in?
     current_user.present?
   end
+
+  # Require that a current user is authenticated and an administrator
+  def require_administrator
+    redirect_to recognitions_path unless logged_in?# && User.administrator?(current_user)
+    # TODO: add check for developer mode so this can work without SSO
+    # redirect_to recognitions_path unless logged_in? && User.administrator?(current_user)
+  end
 end

--- a/app/helpers/auth_helper.rb
+++ b/app/helpers/auth_helper.rb
@@ -14,10 +14,13 @@ module AuthHelper
     current_user.present?
   end
 
+  def valid_administrator?
+    User.administrator?(current_user.id) || current_user.developer?
+  end
+
   # Require that a current user is authenticated and an administrator
   def require_administrator
-    redirect_to recognitions_path unless logged_in?# && User.administrator?(current_user)
-    # TODO: add check for developer mode so this can work without SSO
-    # redirect_to recognitions_path unless logged_in? && User.administrator?(current_user)
+    # redirect_to recognitions_path unless logged_in?# && User.administrator?(current_user)
+    redirect_to recognitions_path unless logged_in? && valid_administrator?
   end
 end

--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -2,6 +2,7 @@
 
 require 'csv'
 
+# StatisticsHelper methods
 module StatisticsHelper
   # Given result set of Recognitions between a date range, generate a csv for an administrator
   # @param results
@@ -13,13 +14,17 @@ module StatisticsHelper
       csv << attributes
 
       results.each do |recognition|
-        nominee = recognition.employee.display_name
-        nominator = recognition.user.full_name
-        value = recognition.library_value
-        anonymous = recognition.anonymous
-        submitted = recognition.created_at
-        csv << [nominee, nominator, value, anonymous, submitted]
+        csv << recognition_row(recognition)
       end
     end
+  end
+
+  def recognition_row(recognition)
+    nominee = recognition.employee.display_name
+    nominator = recognition.user.full_name
+    value = recognition.library_value
+    anonymous = recognition.anonymous
+    submitted = recognition.created_at
+    [nominee, nominator, value, anonymous, submitted]
   end
 end

--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+module StatisticsHelper
+  # Given result set of Recognitions between a date range, generate a csv for an administrator
+  # @param results
+  # @return [String] csv of results
+  def generate_csv(results)
+    attributes = %w[Reconizee Recognizer Value Anonymous Submitted]
+
+    CSV.generate(headers: true) do |csv|
+      csv << attributes
+
+      results.each do |recognition|
+        nominee = recognition.employee.display_name
+        nominator = recognition.user.full_name
+        value = recognition.library_value
+        anonymous = recognition.anonymous
+        submitted = recognition.created_at
+        csv << [nominee, nominator, value, anonymous, submitted]
+      end
+    end
+  end
+end

--- a/app/models/recognition.rb
+++ b/app/models/recognition.rb
@@ -6,4 +6,9 @@ class Recognition < ApplicationRecord
   belongs_to :employee
 
   validates :library_value, :description, presence: true
+
+  # A custom finder used for identifying records created between a given date range
+  def self.created_between(start_date, end_date)
+    where(created_at: start_date..end_date)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
       provider = access_token.provider
       name = access_token.info.name
     rescue StandardError => e
-      logger.warn "shibboleth: #{e}"
+      logger.warn "shibboleth: #{e}" && return
     end
     User.find_by(uid: uid, provider: provider) ||
       User.create(uid: uid, provider: provider, email: email, full_name: name)
@@ -29,6 +29,10 @@ class User < ApplicationRecord
 
   def self.administrator?(uid)
     Ldap::Queries.hifive_group(uid) == uid
+  end
+
+  def developer?
+    provider.eql?('developer')
   end
 
   # Determine whether the authenticated Shib user is Library staff

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -1,7 +1,3 @@
-<%
-  s_date = params[:start_date] ? params[:start_date] : ""
-  e_date = params[:end_date] ? params[:end_date] : ""
-%>
 <div class="text-center"><h3>Recognition Statistics</h3></div>
 <br>
 <div class="center-block">

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -1,0 +1,18 @@
+<%
+  s_date = params[:start_date] ? params[:start_date] : ""
+  e_date = params[:end_date] ? params[:end_date] : ""
+%>
+<div class="text-center"><h3>Recognition Statistics</h3></div>
+<br>
+<div class="center-block">
+<%= form_tag statistics_path, method: "GET", class: "navbar-form" do %>
+    <div class="input-daterange input-group" id="datepicker">
+      <input type="text" class="input-sm form-control" name="start_date" />
+      <span class="input-group-addon">to</span>
+      <input type="text" class="input-sm form-control" name="end_date" />
+    </div>
+    <br>
+    <%= submit_tag "Submit", name: nil, class: "btn btn-primary" %>
+<% end %>
+</div>
+

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -3,9 +3,9 @@
 <div class="center-block">
 <%= form_tag statistics_path, method: "GET", class: "navbar-form" do %>
     <div class="input-daterange input-group" id="datepicker">
-      <input type="text" class="input-sm form-control" name="start_date" />
+      <input type="text" aria-label="Start Date" class="input-sm form-control" name="start_date" />
       <span class="input-group-addon">to</span>
-      <input type="text" class="input-sm form-control" name="end_date" />
+      <input type="text" aria-label="End Date" class="input-sm form-control" name="end_date" />
     </div>
     <br>
     <%= submit_tag "Submit", name: nil, class: "btn btn-primary" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   resources :recognitions
+  resources :statistics
   root 'recognitions#index'
 
   # Shib/AD auth

--- a/spec/controllers/statistics_controller_spec.rb
+++ b/spec/controllers/statistics_controller_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe StatisticsController, type: :controller do
 
       before do
         set_current_user
+        mock_valid_library_employee
+        mock_valid_library_administrator
         expect(@controller).to receive(:send_data)
           .with(csv_string, csv_options) { @controller.render nothing: true }
       end
@@ -44,6 +46,8 @@ RSpec.describe StatisticsController, type: :controller do
 
     before do
       set_current_user
+      mock_valid_library_employee
+      mock_valid_library_administrator
     end
 
     it 'should respond with a flash notification' do

--- a/spec/controllers/statistics_controller_spec.rb
+++ b/spec/controllers/statistics_controller_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe StatisticsController, type: :controller do
+  describe "GET index" do
+    context 'with statistics results' do
+      let!(:recognition_in_range) { FactoryBot.create(:recognition,
+                                                  user: user,
+                                                  created_at: Time.parse('2018-10-01'),
+                                                  library_value: 'collab',
+                                                  description: 'in report',
+                                                  employee: employee) }
+      let!(:recognition_outside_range) { FactoryBot.create(:recognition,
+                                                  user: user,
+                                                  created_at: Time.parse('2017-10-01'),
+                                                  library_value: 'flexible',
+                                                  description: 'not in report',
+                                                  employee: employee) }
+      let(:employee) { FactoryBot.create(:employee) }
+      let(:user) { FactoryBot.create(:user) }
+      let(:csv_string) { "Reconizee,Recognizer,Value,Anonymous,Submitted\nMyString,Jane Triton,collab,false,2018-10-01 00:00:00 UTC\n" }
+      let(:csv_options) { {:filename=>"highfive-stats-2018-10-01-2018-10-15.csv"} }
+
+      before do
+        set_current_user
+        expect(@controller).to receive(:send_data)
+          .with(csv_string, csv_options) { @controller.render nothing: true }
+      end
+
+      it "streams the csv report back to the administrator" do
+        get :index, params: { start_date: '2018-10-01', end_date: '2018-10-15' }
+      end
+    end
+  end
+
+  context 'without any results' do
+    let!(:recognition_outside_range) { FactoryBot.create(:recognition,
+                                                user: user,
+                                                created_at: Time.parse('2018-10-01'),
+                                                library_value: 'collab',
+                                                description: 'in report',
+                                                employee: employee) }
+    let(:employee) { FactoryBot.create(:employee) }
+    let(:user) { FactoryBot.create(:user) }
+
+    before do
+      set_current_user
+    end
+
+    it 'should respond with a flash notification' do
+      get :index, params: { start_date: '1999-10-01', end_date: '1999-10-15' }
+      expect(flash[:notice]).to be_present
+    end
+  end
+end

--- a/spec/helpers/statistics_helper_spec.rb
+++ b/spec/helpers/statistics_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe StatisticsHelper, type: :helper do
+  describe '#generate_csv' do
+    let(:recognition1) { FactoryBot.build_stubbed(:recognition,
+                                                 user: user,
+                                                 description: 'in report',
+                                                 employee: employee) }
+    let(:recognition2) { FactoryBot.build_stubbed(:recognition,
+                                                 user: user,
+                                                 description: 'not in report',
+                                                 employee: employee) }
+    let(:employee) { FactoryBot.build_stubbed(:employee) }
+    let(:user) { FactoryBot.build_stubbed(:user) }
+
+    it 'generates a csv with a set of Recognition records' do
+      RECORDS_AND_HEADER_ROW = 3
+      expect(helper.generate_csv([recognition1,recognition2]).split(/\n/).size).to eq RECORDS_AND_HEADER_ROW
+    end
+  end
+end

--- a/spec/models/recognition_spec.rb
+++ b/spec/models/recognition_spec.rb
@@ -19,4 +19,22 @@ RSpec.describe Recognition, type: :model do
       expect(recognition).to be_valid
     end
   end
+
+  describe '.created_between' do
+    let!(:recognition1) { FactoryBot.create(:recognition,
+                                                 user: user,
+                                                 created_at: Time.parse('2018-10-01'),
+                                                 description: 'in report',
+                                                 employee: employee) }
+    let!(:recognition2) { FactoryBot.create(:recognition,
+                                                 user: user,
+                                                 created_at: Time.parse('2017-10-01'),
+                                                 description: 'not in report',
+                                                 employee: employee) }
+    let(:employee) { FactoryBot.create(:employee) }
+    let(:user) { FactoryBot.create(:user) }
+    it 'finds recognitions in a given date range' do
+      expect(described_class.created_between('2018-01-01', '2018-12-31').map(&:description)).to eq(['in report'])
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,6 +12,22 @@ RSpec.describe User, type: :model do
     uid: 'test'
   })}
 
+  describe "#developer?" do
+    it 'should return true when provider is developer' do
+      auth_hash.provider = 'developer'
+      auth_hash.uid = '1'
+      user = User.find_or_create_for_developer(auth_hash)
+      expect(user.developer?).to be true
+    end
+
+    it 'should return false when provider is shibboleth' do
+      user = User.find_or_create_for_shibboleth(auth_hash)
+      expect(user.developer?).to be false
+    end
+
+
+  end
+
   describe ".find_or_create_for_developer" do
     it "should create a User for first time user" do
       auth_hash.provider = 'developer'
@@ -44,8 +60,9 @@ RSpec.describe User, type: :model do
       expect(user.full_name).to eq('Dr. Seuss')
     end
 
-    it 'should throw an error with bad or missing response information' do
-      expect { User.find_or_create_for_shibboleth(invalid_auth_hash_missing_info) }.to raise_error(StandardError)
+    it 'should not persist a shib response with bad or missing information' do
+      User.find_or_create_for_shibboleth(invalid_auth_hash_missing_info)
+      expect(User.find_by(uid: 'test', provider: 'shibboleth')).to be nil
     end
   end
 

--- a/spec/support/user.rb
+++ b/spec/support/user.rb
@@ -12,3 +12,7 @@ end
 def sign_out_developer
   visit new_session_path
 end
+
+def mock_valid_library_administrator
+  allow(User).to receive(:administrator?).and_return('')
+end


### PR DESCRIPTION
Fixes #41 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [x] Configuration updated (if needed)?

#### What does this PR do?

Add initial statistics support based on #41 . It's restricted to administrators, and returns a CSV when there are results available via `send_data`.

The UI is pretty hideous, but I'm assuming we'll dial that in with the help of David. I was aiming for initial feature complete.

##### Why are we doing this? Any context of related work?
References #41 

#### Where should a reviewer start?
I intentionally tried to make these commits granular because a lot of files had to be touched. So I might work from those back to front AND/OR start with the tests.

#### Manual testing steps?
You'll need to load some data and create a few recognitions if you want to test via the UI.

@VivianChu  - please review
