### PR TITLE
OptOutLinks feature

### DIFF
--- a/app/controllers/opt_out_links_controller.rb
+++ b/app/controllers/opt_out_links_controller.rb
@@ -22,8 +22,10 @@ class OptOutLinksController < ApplicationController
   # Finish the optout process by suppressing the recognition and removing the optoutlink
   def complete_optout(optout_record)
     recognition_record = Recognition.find_by(id: optout_record.recognition_id)
-    recognition_record.suppressed = true
-    recognition_record.save!
+    if recognition_record
+      recognition_record.suppressed = true
+      recognition_record.save!
+    end
     optout_record.delete
   end
 

--- a/app/controllers/opt_out_links_controller.rb
+++ b/app/controllers/opt_out_links_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# OptOutLinksController
+class OptOutLinksController < ApplicationController
+  # GET /optout
+  def optout
+    return unless optout_params[:key]
+
+    optout_record = OptOutLink.find_by(key: optout_params[:key])
+    notice = ''
+    if optout_record.nil?
+      notice = 'No recognitions matched your key'
+    else
+      complete_optout(optout_record)
+      notice = 'Your recogntion has been suppressed from public view'
+    end
+    redirect_to recognitions_url, notice: notice
+  end
+
+  private
+
+  # Finish the optout process by suppressing the recognition and removing the optoutlink
+  def complete_optout(optout_record)
+    recognition_record = Recognition.find_by(id: optout_record.recognition_id)
+    recognition_record.suppressed = true
+    recognition_record.save!
+    optout_record.delete
+  end
+
+  def optout_params
+    params.permit(:key)
+  end
+end

--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -8,7 +8,7 @@ module StatisticsHelper
   # @param results
   # @return [String] csv of results
   def generate_csv(results)
-    attributes = %w[Reconizee Recognizer Value Anonymous Submitted]
+    attributes = %w[Reconizee Recognizer Value Anonymous Opted-Out Submitted]
 
     CSV.generate(headers: true) do |csv|
       csv << attributes
@@ -24,7 +24,8 @@ module StatisticsHelper
     nominator = recognition.user.full_name
     value = recognition.library_value
     anonymous = recognition.anonymous
+    suppressed = recognition.suppressed
     submitted = recognition.created_at
-    [nominee, nominator, value, anonymous, submitted]
+    [nominee, nominator, value, anonymous, suppressed, submitted]
   end
 end

--- a/app/models/opt_out_link.rb
+++ b/app/models/opt_out_link.rb
@@ -1,0 +1,2 @@
+class OptOutLink < ApplicationRecord
+end

--- a/app/models/opt_out_link.rb
+++ b/app/models/opt_out_link.rb
@@ -2,6 +2,15 @@
 
 # OptOutLinks for Recogntions
 class OptOutLink < ApplicationRecord
+  # overrides AR::Base method
+  # allows ActionPack to contruct optoutlinks using the key
+  # optout_example = OptOutLink.first
+  # optout_path(optout_example) => "/optout/the-digest-key"
+  # optout_url(optout_example) => "http://www.example.com/optout/a-test-for-path"
+  def to_param
+    key
+  end
+
   # Will find and remove any OptOutLinks that have expired
   def self.audit_expired_links
     where('DATE(expires) <= ?', Time.zone.today).delete_all

--- a/app/models/opt_out_link.rb
+++ b/app/models/opt_out_link.rb
@@ -1,2 +1,9 @@
+# frozen_string_literal: true
+
+# OptOutLinks for Recogntions
 class OptOutLink < ApplicationRecord
+  # Will find and remove any OptOutLinks that have expired
+  def self.audit_expired_links
+    where('DATE(expires) <= ?', Time.zone.today).delete_all
+  end
 end

--- a/app/models/recognition.rb
+++ b/app/models/recognition.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require 'digest/bubblebabble'
+
 # Recognition
 class Recognition < ApplicationRecord
+  after_create :generate_link
+
   belongs_to :user
   belongs_to :employee
 
@@ -10,5 +14,11 @@ class Recognition < ApplicationRecord
   # A custom finder used for identifying records created between a given date range
   def self.created_between(start_date, end_date)
     where(created_at: start_date..end_date)
+  end
+
+  # Generate an OptOutLink for this Recognition
+  def generate_link
+    key = Digest::SHA1.bubblebabble(id.to_s + Time.zone.now.to_s)
+    OptOutLink.new(key: key, recognition_id: id, expires: 6.months.from_now).save
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root 'recognitions#index'
 
   # OptOutLinks
-  get '/optout', to: 'opt_out_links#optout', as: :optout
+  get '/optout/:key', to: 'opt_out_links#optout', as: :optout
 
   # Shib/AD auth
   get "/signin", to: 'sessions#new', as: :signin

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@ Rails.application.routes.draw do
   resources :statistics
   root 'recognitions#index'
 
+  # OptOutLinks
+  get '/optout', to: 'opt_out_links#optout', as: :optout
+
   # Shib/AD auth
   get "/signin", to: 'sessions#new', as: :signin
   get "/auth/shibboleth", as: :shibboleth

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,6 +6,6 @@ every 1.day at: '3:00 am' do
 end
 
 # Remove expired OptOutLinks
-every 1.day at: '3:00 am' do
+every 1.day at: '2:00 am' do
   runner 'OptOutLink.audit_expired_links'
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -4,3 +4,8 @@
 every 1.day at: '3:00 am' do
   runner 'Ldap::Queries.employees'
 end
+
+# Remove expired OptOutLinks
+every 1.day at: '3:00 am' do
+  runner 'OptOutLink.audit_expired_links'
+end

--- a/db/migrate/20181109213520_create_opt_out_links.rb
+++ b/db/migrate/20181109213520_create_opt_out_links.rb
@@ -1,0 +1,11 @@
+class CreateOptOutLinks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :opt_out_links do |t|
+      t.string :key, null: false
+      t.bigint :recognition_id, null: false
+      t.datetime :expires, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181109225636_add_suppressed_to_recognitions.rb
+++ b/db/migrate/20181109225636_add_suppressed_to_recognitions.rb
@@ -1,0 +1,5 @@
+class AddSuppressedToRecognitions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :recognitions, :suppressed, :bool, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_22_161349) do
+ActiveRecord::Schema.define(version: 2018_11_09_213520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,14 @@ ActiveRecord::Schema.define(version: 2018_10_22_161349) do
     t.string "manager", null: false
     t.string "email", null: false
     t.string "display_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "opt_out_links", force: :cascade do |t|
+    t.string "key", null: false
+    t.bigint "recognition_id", null: false
+    t.datetime "expires", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_09_213520) do
+ActiveRecord::Schema.define(version: 2018_11_09_225636) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 2018_11_09_213520) do
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.bigint "employee_id"
+    t.boolean "suppressed", default: false
     t.index ["employee_id"], name: "index_recognitions_on_employee_id"
     t.index ["user_id"], name: "index_recognitions_on_user_id"
   end

--- a/spec/controllers/opt_out_links_controller_spec.rb
+++ b/spec/controllers/opt_out_links_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe OptOutLinksController, type: :controller do
+  describe "GET #optout" do
+    let!(:recognition) { FactoryBot.create(:recognition,
+                                            user: user,
+                                            created_at: Time.parse('2018-10-01'),
+                                            library_value: 'collab',
+                                            description: 'perhaps something not nice',
+                                            employee: employee) }
+    let(:employee) { FactoryBot.create(:employee) }
+    let(:user) { FactoryBot.create(:user) }
+
+    it 'should suppress the recognition with a valid key' do
+      get :optout, params: { key: OptOutLink.first.key }
+      expect(Recognition.find_by(id: recognition.id).suppressed).to be(true)
+    end
+
+    it 'should do nothing with an valid key' do
+      get :optout, params: { key: 'utter-nonsense' }
+      expect(recognition.suppressed).to be(false)
+    end
+  end
+end

--- a/spec/controllers/statistics_controller_spec.rb
+++ b/spec/controllers/statistics_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe StatisticsController, type: :controller do
                                                   employee: employee) }
       let(:employee) { FactoryBot.create(:employee) }
       let(:user) { FactoryBot.create(:user) }
-      let(:csv_string) { "Reconizee,Recognizer,Value,Anonymous,Submitted\nMyString,Jane Triton,collab,false,2018-10-01 00:00:00 UTC\n" }
+      let(:csv_string) { "Reconizee,Recognizer,Value,Anonymous,Opted-Out,Submitted\nMyString,Jane Triton,collab,false,false,2018-10-01 00:00:00 UTC\n" }
       let(:csv_options) { {:filename=>"highfive-stats-2018-10-01-2018-10-15.csv"} }
 
       before do

--- a/spec/factories/opt_out_links.rb
+++ b/spec/factories/opt_out_links.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :opt_out_link do
+    key { "MyString" }
+    recognition_id { "" }
+    expires { "2018-11-09 21:35:20" }
+  end
+end

--- a/spec/factories/opt_out_links.rb
+++ b/spec/factories/opt_out_links.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :opt_out_link do
     key { "MyString" }
-    recognition_id { "" }
+    recognition_id { "1" }
     expires { "2018-11-09 21:35:20" }
   end
 end

--- a/spec/models/opt_out_link_spec.rb
+++ b/spec/models/opt_out_link_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe OptOutLink, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/opt_out_link_spec.rb
+++ b/spec/models/opt_out_link_spec.rb
@@ -1,5 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe OptOutLink, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '.audit_expired_links' do
+    let!(:expired_link) { FactoryBot.create(:opt_out_link,
+                                                 key: 'expired-key',
+                                                 expires: Time.parse('2018-10-01')) }
+    let!(:non_expired_link) { FactoryBot.create(:opt_out_link,
+                                                 key: 'valid-key',
+                                                 expires: Time.parse('2020-10-01')) }
+    it 'finds expired links and deletes them' do
+      travel_to Date.new(2018, 10, 02) do
+        described_class.audit_expired_links
+        expect(OptOutLink.count).to be(1)
+        expect(OptOutLink.first.key).to eq('valid-key')
+      end
+    end
+  end
 end

--- a/spec/models/recognition_spec.rb
+++ b/spec/models/recognition_spec.rb
@@ -20,6 +20,21 @@ RSpec.describe Recognition, type: :model do
     end
   end
 
+  describe '#generate_link' do
+    let!(:recognition) { FactoryBot.create(:recognition,
+                                                 user: user,
+                                                 created_at: Time.parse('2018-10-01'),
+                                                 description: 'in report',
+                                                 employee: employee) }
+    let(:employee) { FactoryBot.create(:employee) }
+    let(:user) { FactoryBot.create(:user) }
+
+    it 'generates an OptOutLink' do
+      expect(OptOutLink.count).to be(1)
+      expect(OptOutLink.first.recognition_id).to eq(recognition.id)
+    end
+  end
+
   describe '.created_between' do
     let!(:recognition1) { FactoryBot.create(:recognition,
                                                  user: user,

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,4 +75,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include ActiveSupport::Testing::TimeHelpers
 end


### PR DESCRIPTION
Fixes #75 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [x] Configuration updated (if needed)?

#### What does this PR do?
Introduces opt out/suppression links for recognitions. It adds a `suppressed` field to Recognitions, which defaults to `false`, which is set to `true` if an opt out link is used. This data is now added to the csv export for statistics.

The opt out links expire after 6 months, and a whenever cron has been setup to check for expired links nightly and remove them. There are tests in place for this, note the use of the relatively new `travel_to` method provided by `ActiveSupport::Testing::TimeHelpers`

##### Why are we doing this? Any context of related work?
References #75 #22 

#### Where should a reviewer start?
I tried to make individual commits to target each piece of the work. The tests would be good as well, and please let me know if i missed any!

#### Manual testing steps?
You can create a Recognition in the UI, using this branch. Then go in to rails console and grab the `key` for the related OptOutLink. If you want to test using the link, you could use it `localhost:3000/optout/<key>`

#### Database changes
- Adds OptOutLink table
- Adds `suppressed` column to Recognition

@VivianChu  - please review
