### PR TITLE
Feature/fix library values

### DIFF
--- a/app/helpers/recognitions_helper.rb
+++ b/app/helpers/recognitions_helper.rb
@@ -3,6 +3,7 @@
 # RecognitionsHelper
 module RecognitionsHelper
   def library_values
-    LIBRARY_VALUES
+    # helper for form needs to be [label, value]
+    LIBRARY_VALUES.to_a.map { |entry| [entry[1], entry[0]] }
   end
 end

--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -22,7 +22,7 @@ module StatisticsHelper
   def recognition_row(recognition)
     nominee = recognition.employee.display_name
     nominator = recognition.user.full_name
-    value = recognition.library_value
+    value = LIBRARY_VALUES[recognition.library_value]
     anonymous = recognition.anonymous
     suppressed = recognition.suppressed
     submitted = recognition.created_at

--- a/app/views/recognitions/index.html.erb
+++ b/app/views/recognitions/index.html.erb
@@ -28,7 +28,7 @@
         <% else %>
         <td></td>
         <% end %>
-        <td><%= recognition.library_value %></td>
+        <td><%= LIBRARY_VALUES[ recognition.library_value ] %></td>
         <td><%= recognition.description %></td>
         <td><%= recognition.anonymous ? 'Anonymous' : 'No' %></td>
         <td><%= recognition.user.full_name %></td>

--- a/app/views/recognitions/show.html.erb
+++ b/app/views/recognitions/show.html.erb
@@ -10,7 +10,7 @@
 
 <p>
   <strong>Library value:</strong>
-  <%= @recognition.library_value %>
+  <%= LIBRARY_VALUES[@recognition.library_value] %>
 </p>
 
 <p>

--- a/config/library_values.yml
+++ b/config/library_values.yml
@@ -1,16 +1,6 @@
 ---
--
-  - 'Community, Diversity, and Inclusion'
-  - 'diversity'
--
-  - 'Collaboration and Communication'
-  - 'collab'
--
-  - 'Innovation, Creativity, and Risk-taking'
-  - 'innovate'
--
-  - 'Responsiveness, Flexibility, and Continuous Improvement'
-  - 'flexible'
--
-  - 'Service and Excellence'
-  - 'service'
+diversity: 'Community, Diversity, and Inclusion'
+collab: 'Collaboration and Communication'
+innovate: 'Innovation, Creativity, and Risk-taking'
+flexible: 'Responsiveness, Flexibility, and Continuous Improvement'
+service: 'Service and Excellence'

--- a/spec/controllers/statistics_controller_spec.rb
+++ b/spec/controllers/statistics_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe StatisticsController, type: :controller do
                                                   employee: employee) }
       let(:employee) { FactoryBot.create(:employee) }
       let(:user) { FactoryBot.create(:user) }
-      let(:csv_string) { "Reconizee,Recognizer,Value,Anonymous,Opted-Out,Submitted\nMyString,Jane Triton,collab,false,false,2018-10-01 00:00:00 UTC\n" }
+      let(:csv_string) { "Reconizee,Recognizer,Value,Anonymous,Opted-Out,Submitted\nMyString,Jane Triton,Collaboration and Communication,false,false,2018-10-01 00:00:00 UTC\n" }
       let(:csv_options) { {:filename=>"highfive-stats-2018-10-01-2018-10-15.csv"} }
 
       before do

--- a/spec/helpers/recognitions_helper_spec.rb
+++ b/spec/helpers/recognitions_helper_spec.rb
@@ -1,7 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe RecognitionsHelper, type: :helper do
-  describe '#library_values' do
-    specify { expect(helper.library_values).to eq(LIBRARY_VALUES) }
-  end
 end

--- a/spec/models/opt_out_link_spec.rb
+++ b/spec/models/opt_out_link_spec.rb
@@ -16,4 +16,11 @@ RSpec.describe OptOutLink, type: :model do
       end
     end
   end
+
+  describe '#to_param' do
+    let!(:expired_link) { FactoryBot.build_stubbed(:opt_out_link, key: 'valid-key')}
+    it 'overrides to_param for custom route url with key' do
+      expect(expired_link.to_param).to eq('valid-key')
+    end
+  end
 end

--- a/spec/system/recognition_spec.rb
+++ b/spec/system/recognition_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'interacting with recognitions', type: :system do
     click_on('Create Recognition')
     visit recognitions_path
     expect(page).to have_content('Really Long Text...')
-    expect(page).to have_content('collab')
+    expect(page).to have_content('Collaboration and Communication')
     expect(page).to have_content('Joe Employee')
   end
 
@@ -70,7 +70,7 @@ RSpec.describe 'interacting with recognitions', type: :system do
     click_on('Update Recognition')
 
     expect(page).to have_content('I changed my mind')
-    expect(page).to have_content('collab')
+    expect(page).to have_content('Collaboration and Communication')
     expect(page).to have_content('Joe Employee')
   end
 


### PR DESCRIPTION
Fixes #77 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?

#### What does this PR do?
This PR changes the stored yml file to a hash for library values. It updates the helper method for the recognition form to create an array that it expects, and otherwise does a lookup for displaying to end users. This will be needed for the email and rss implementations as well.

##### Why are we doing this? Any context of related work?
References #77 

#### Where should a reviewer start?
See updated tests and the tweaks to the helper to get a valid array back for the form.

@VivianChu  - please review
