### PR TITLE
ldap: remove manager_details query

### DIFF
--- a/app/services/ldap/queries.rb
+++ b/app/services/ldap/queries.rb
@@ -73,29 +73,5 @@ module Ldap
       validate_ldap_response
       result
     end
-
-    # Query manager email and name for a given employee
-    # @param [String] dname information for the manager to lookup
-    #   Example: CN=drseuss,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU
-    # @return [Hash] manager information with name and email keys
-    # Example: { first_name: 'Dr.', last_name: 'Seuss', email: 'thedoctor@ucsd.edu' }
-    # rubocop:disable Metrics/MethodLength
-    def self.manager_details(dname)
-      result = {}
-      ldap_connection.search(
-        base: dname,
-        return_result: false,
-        filter: Net::LDAP::Filter.eq('objectcategory', 'user'),
-        attributes: %w[mail givenName sn]
-      ) do |m|
-        result[:email] = m.mail.first
-        result[:first_name] = m.givenName.first
-        result[:last_name] = m.sn.first
-      end
-      validate_ldap_response
-
-      result
-    end
-    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/spec/services/ldap/queries_spec.rb
+++ b/spec/services/ldap/queries_spec.rb
@@ -69,24 +69,6 @@ RSpec.describe Ldap::Queries, type: :service do
     end
   end
 
-  describe '.manager_details' do
-    let(:dn) { 'CN=drseuss,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU' }
-    before do
-      entry = Net::LDAP::Entry.new(dn)
-      entry['sn'] = 'Seuss'
-      entry['givenname'] = 'Dr.'
-      entry['mail'] = 'drseuss@ucsd.edu'
-      mock_ldap_validation
-      allow(mock_ldap_connection).to receive(:search).and_yield(entry)
-    end
-
-    it 'returns a hash of manager information for a given employee' do
-      expect(described_class.manager_details(dn)).to eq({:email=>"drseuss@ucsd.edu",
-                                                         :first_name=>"Dr.",
-                                                         :last_name=>"Seuss"})
-    end
-  end
-
   describe '.validate_ldap_response' do
     it 'raises an error with a non-zero exit code' do
       operation_result = OpenStruct.new(:code => 1, :message => 'Something terrible happened')


### PR DESCRIPTION
We have the Employee table we can leverage for this information, already
populated from Ldap.

Fixes #82 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?

#### What does this PR do?

Deletes code we're not using, which brings me :joy: 

##### Why are we doing this? Any context of related work?
References #82 

@VivianChu - please review
