### PR TITLE
recognitions: add rss feed

### DIFF
--- a/app/controllers/recognitions_controller.rb
+++ b/app/controllers/recognitions_controller.rb
@@ -14,7 +14,7 @@ class RecognitionsController < ApplicationController
 
   # GET /feed.rss
   def feed
-    @recognitions = Recognition.last(15)
+    @recognitions = Recognition.all.order(:created_at).reverse_order.first(15)
     respond_to do |format|
       format.rss { render layout: false }
     end

--- a/app/controllers/recognitions_controller.rb
+++ b/app/controllers/recognitions_controller.rb
@@ -12,6 +12,14 @@ class RecognitionsController < ApplicationController
     @recognitions = Recognition.all
   end
 
+  # GET /feed.rss
+  def feed
+    @recognitions = Recognition.last(15)
+    respond_to do |format|
+      format.rss { render layout: false }
+    end
+  end
+
   # GET /recognitions/1
   # GET /recognitions/1.json
   def show; end

--- a/app/views/recognitions/feed.rss.builder
+++ b/app/views/recognitions/feed.rss.builder
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+xml.instruct! :xml, version: '1.0'
+xml.rss version: '2.0' do
+  xml.channel do
+    xml.title 'High Five!'
+    xml.description 'Employee recognition program for the UC San Diego Library'
+    xml.link root_url
+
+    @recognitions.each do |recognition|
+      xml.item do
+        xml.title "#{recognition.employee.name}
+                  was recognized for #{LIBRARY_VALUES[recognition.library_value]}!"
+        xml.description recognition.description
+        xml.pubDate recognition.created_at.to_s(:rfc822)
+        xml.link recognition_url(recognition)
+        xml.guid recognition_url(recognition)
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@ Rails.application.routes.draw do
   resources :statistics
   root 'recognitions#index'
 
+  # RSS feed
+  get 'feed', to: 'recognitions#feed', as: :feed
+
   # OptOutLinks
   get '/optout/:key', to: 'opt_out_links#optout', as: :optout
 
@@ -13,6 +16,6 @@ Rails.application.routes.draw do
   match "/auth/shibboleth/callback" => "sessions#shibboleth", as: :callback, via: [:get, :post]
   match "/signout" => "sessions#destroy", as: :signout, via: [:get, :post]
   match "/auth/failure", to: 'sessions#failure', as: :failed_signin, via: [:get, :post]
-  
+
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end

--- a/spec/controllers/recognitions_controller_spec.rb
+++ b/spec/controllers/recognitions_controller_spec.rb
@@ -1,5 +1,12 @@
 require 'rails_helper'
 
-# RecognitionsController specs placeholder
+# RecognitionsController
 RSpec.describe RecognitionsController, type: :controller do
+  describe "GET Recognitions RSS feed" do
+    it "returns an RSS feed" do
+      get :feed, :format => "rss"
+      expect(response).to be_success
+      expect(response.content_type).to eq("application/rss+xml")
+    end
+  end
 end


### PR DESCRIPTION
Fixes #39 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?

#### What does this PR do?

Adds a basic RSS feed for recognitions. Note that while images are technically possible to include in an RSS feed, David T confirmed that the Confluence RSS feed widget cannot use them. So they're not here, alas.

##### Why are we doing this? Any context of related work?
References #39 

@VivianChu  - please review
