### PR TITLE
Feature/access controls

### DIFF
--- a/app/controllers/opt_out_links_controller.rb
+++ b/app/controllers/opt_out_links_controller.rb
@@ -14,7 +14,7 @@ class OptOutLinksController < ApplicationController
       complete_optout(optout_record)
       notice = 'Your recogntion has been suppressed from public view'
     end
-    redirect_to recognitions_url, notice: notice
+    redirect_to root_url, notice: notice
   end
 
   private

--- a/app/controllers/recognitions_controller.rb
+++ b/app/controllers/recognitions_controller.rb
@@ -3,7 +3,7 @@
 # RecognitionsController
 class RecognitionsController < ApplicationController
   helper RecognitionsHelper
-  before_action :require_user, only: %i[new edit create update destroy]
+  before_action :require_user, only: %i[show index new edit create update destroy]
   before_action :set_recognition, only: %i[show edit update destroy]
 
   # GET /recognitions
@@ -23,6 +23,9 @@ class RecognitionsController < ApplicationController
   # GET /recognitions/1
   # GET /recognitions/1.json
   def show; end
+
+  # Homepage for app
+  def front; end
 
   # GET /recognitions/new
   def new

--- a/app/controllers/recognitions_controller.rb
+++ b/app/controllers/recognitions_controller.rb
@@ -5,6 +5,7 @@ class RecognitionsController < ApplicationController
   helper RecognitionsHelper
   before_action :require_user, only: %i[show index new edit create update destroy]
   before_action :set_recognition, only: %i[show edit update destroy]
+  before_action :authorize_editor, only: %i[edit update destroy]
 
   # GET /recognitions
   # GET /recognitions.json
@@ -78,6 +79,13 @@ class RecognitionsController < ApplicationController
   end
 
   private
+
+  # Ensure the current user is allowed to edit/update/delete the current recognition
+  def authorize_editor
+    # rubocop:disable Metrics/LineLength
+    redirect_to @recognition, notice: 'You are only allowed to modify your own recognitions' unless can_administrate?(@recognition)
+    # rubocop:enable Metrics/LineLength
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_recognition

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -68,5 +68,4 @@ class SessionsController < ApplicationController
     redirect_to(session[:forwarding_url] || default)
     session.delete(:forwarding_url)
   end
-
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -19,7 +19,7 @@ class SessionsController < ApplicationController
   end
 
   def failure
-    redirect_to root_url, alert: 'You are not an authorized Library employee'
+    render file: Rails.root.join('public', '403'), formats: [:html], status: 403, layout: false
   end
 
   def find_or_create_user(auth_type)

--- a/app/helpers/auth_helper.rb
+++ b/app/helpers/auth_helper.rb
@@ -19,6 +19,13 @@ module AuthHelper
     User.administrator?(current_user.id) || current_user.developer?
   end
 
+  # Determines when the currently authenticate user is allowed to Edit/Update/Destroy a given recognition
+  # The recognition must belong to the current user or the current user must be an administrator
+  # @param [Recognition] recognition
+  def can_administrate?(recognition)
+    current_user.recognitions.include?(recognition) || User.administrator?(current_user.id)
+  end
+
   # Require that a current user is authenticated and an administrator
   def require_administrator
     redirect_to root_url unless logged_in? && valid_administrator?

--- a/app/helpers/auth_helper.rb
+++ b/app/helpers/auth_helper.rb
@@ -23,7 +23,7 @@ module AuthHelper
   # The recognition must belong to the current user or the current user must be an administrator
   # @param [Recognition] recognition
   def can_administrate?(recognition)
-    current_user.recognitions.include?(recognition) || User.administrator?(current_user.id)
+    current_user.recognitions.include?(recognition) || valid_administrator?
   end
 
   # Require that a current user is authenticated and an administrator

--- a/app/helpers/auth_helper.rb
+++ b/app/helpers/auth_helper.rb
@@ -7,6 +7,7 @@ module AuthHelper
   end
 
   def require_user
+    store_location
     redirect_to signin_path, notice: 'You need to sign in!' unless logged_in?
   end
 
@@ -20,6 +21,12 @@ module AuthHelper
 
   # Require that a current user is authenticated and an administrator
   def require_administrator
-    redirect_to recognitions_path unless logged_in? && valid_administrator?
+    redirect_to root_url unless logged_in? && valid_administrator?
+  end
+
+  # Stores the URL trying to be accessed.
+  # This allows us to redirect them back after SSO authentication
+  def store_location
+    session[:forwarding_url] = request.original_url if request.get?
   end
 end

--- a/app/views/recognitions/home.html.erb
+++ b/app/views/recognitions/home.html.erb
@@ -1,0 +1,9 @@
+<p>
+  <strong>Welcome to High Five!</strong>
+</p>
+
+<% if logged_in? %>
+<%= link_to 'Sign out', signout_path, class: "btn btn-outline-secondary"%>
+<% else %>
+<%= link_to 'Sign in', signin_path, class: "btn btn-outline-secondary"%>
+<% end %>

--- a/app/views/recognitions/index.html.erb
+++ b/app/views/recognitions/index.html.erb
@@ -33,8 +33,13 @@
         <td><%= recognition.anonymous ? 'Anonymous' : 'No' %></td>
         <td><%= recognition.user.full_name %></td>
         <td><%= link_to 'Show', recognition %></td>
+        <% if can_administrate?(recognition) %>
         <td><%= link_to 'Edit', edit_recognition_path(recognition) %></td>
         <td><%= link_to 'Destroy', recognition, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <% else %>
+        <td></td>
+        <td></td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/recognitions/show.html.erb
+++ b/app/views/recognitions/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <% if(File.file?("app/assets/images/photos/#{@recognition.employee.uid}.jpg")) %>
 <p><%= image_tag("photos/#{@recognition.employee.uid}.jpg") %></p>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   resources :recognitions
   resources :statistics
-  root 'recognitions#index'
+  root 'recognitions#home'
 
   # RSS feed
   get 'feed', to: 'recognitions#feed', as: :feed

--- a/spec/controllers/recognitions_controller_spec.rb
+++ b/spec/controllers/recognitions_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RecognitionsController, type: :controller do
   describe "GET Recognitions RSS feed" do
     it "returns an RSS feed" do
       get :feed, :format => "rss"
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response.content_type).to eq("application/rss+xml")
     end
   end

--- a/spec/controllers/statistics_controller_spec.rb
+++ b/spec/controllers/statistics_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe StatisticsController, type: :controller do
       before do
         set_current_user
         mock_valid_library_employee
-        mock_valid_library_administrator
+        mock_library_administrator
         expect(@controller).to receive(:send_data)
           .with(csv_string, csv_options) { @controller.render nothing: true }
       end
@@ -49,7 +49,7 @@ RSpec.describe StatisticsController, type: :controller do
     before do
       set_current_user
       mock_valid_library_employee
-      mock_valid_library_administrator
+      mock_library_administrator
     end
 
     it 'should respond with a flash notification' do

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -5,10 +5,5 @@ FactoryBot.define do
     sequence(:uid) { |n| "user#{n}" }
     full_name { 'Jane Triton' }
     provider { 'shibboleth' }
-
-    # future idea for adding Roles
-    # factory :admin do
-    #   roles { [Role.where(name: "admin").first_or_create] }
-    # end
   end
 end

--- a/spec/requests/recognitions_spec.rb
+++ b/spec/requests/recognitions_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Recognitions", type: :request do
   describe "GET /recognitions" do
     it "works! (now write some real specs)" do
       get recognitions_path
-      expect(response).to have_http_status(200)
+      expect(response).to redirect_to(signin_path)
     end
   end
 end

--- a/spec/support/user.rb
+++ b/spec/support/user.rb
@@ -13,6 +13,10 @@ def sign_out_developer
   visit new_session_path
 end
 
-def mock_valid_library_administrator
-  allow(User).to receive(:administrator?).and_return('')
+def mock_library_administrator
+  allow(User).to receive(:administrator?).and_return(true)
+end
+
+def mock_non_library_administrator
+  allow(User).to receive(:administrator?).and_return(false)
 end

--- a/spec/system/authentication_spec.rb
+++ b/spec/system/authentication_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'authenticating', type: :system do
     end
 
     it 'enforces authentication' do
-      sign_in
+      visit recognitions_path
       expect(page).to have_content('Sign out')
     end
 

--- a/spec/system/authentication_spec.rb
+++ b/spec/system/authentication_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'authenticating', type: :system do
 
     it 'should not allow access to the application' do
       sign_in
-      expect(page).to have_content('You are not an authorized Library employee')
+      expect(page).to have_content('Forbidden')
     end
   end
 

--- a/spec/system/authorization_spec.rb
+++ b/spec/system/authorization_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe 'enforcing authorization in recognitions', type: :system do
+  before do
+    mock_valid_library_employee
+    omniauth_setup_shibboleth
+    mock_email_credential
+  end
+
   let!(:recognition_for_different_user) { FactoryBot.create(:recognition,
                                                 user: user1,
                                                 description: 'employee1 is great',
@@ -18,10 +24,7 @@ RSpec.describe 'enforcing authorization in recognitions', type: :system do
 
   context 'as an administrator' do
     before do
-      mock_valid_library_employee
       mock_library_administrator
-      omniauth_setup_shibboleth
-      mock_email_credential
     end
 
     it 'can see links to edit/delete all records', :aggregate_failures do
@@ -49,10 +52,7 @@ RSpec.describe 'enforcing authorization in recognitions', type: :system do
 
   context 'as a library staff member' do
     before do
-      mock_valid_library_employee
       mock_non_library_administrator
-      omniauth_setup_shibboleth
-      mock_email_credential
     end
     it 'can only see links to edit/delete their own records', :aggregate_failures do
       visit recognitions_path

--- a/spec/system/recognition_spec.rb
+++ b/spec/system/recognition_spec.rb
@@ -9,7 +9,12 @@ RSpec.describe 'interacting with recognitions', type: :system do
 
   it 'enforces authentication' do
     visit new_recognition_path
-    expect(page).to have_content('Sign out')
+    expect(page).to have_content('You have successfully authenticated')
+  end
+
+  it 'redirects after authentication to originally requested path' do
+    visit recognitions_path
+    expect(page).to have_current_path(recognitions_path)
   end
 
   it 'does not allow a user to create a recognition without a recognizee, value, and description' do


### PR DESCRIPTION
Fixes #74 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [x] Configuration updated (if needed)?

#### What does this PR do?
A few things:
- Introduces a landing page `front` that can be used for branding
- Add `show` and `index` to the `require_user` callback to enforce global auth for recognitions
- Add `authorize_editor` callback for recognitions to only allow Users to edit recognitions if they were the creator OR are an admin
- Store the requested URL in a session variable so the user can be directed there after login. Example a user follows a link to a recognition from the LiSN rss feed (recognition/123) and is then asked to authenticate. Previously they would have been redirected to the index page, which would have been very confusing. Now they should be routed to recognition/123 after authenticating
- Added tests for everything I could think of

##### Why are we doing this? Any context of related work?
References #74 

#### Where should a reviewer start?
Each commit is more or less a chunk of the work defined above. It may be worth working through those and their commit messages.

@VivianChu  - please review
