### PR TITLE
recognitions: reverse chronological sort for index

### DIFF
--- a/app/controllers/recognitions_controller.rb
+++ b/app/controllers/recognitions_controller.rb
@@ -10,12 +10,12 @@ class RecognitionsController < ApplicationController
   # GET /recognitions
   # GET /recognitions.json
   def index
-    @recognitions = Recognition.all
+    @recognitions = Recognition.all.order('created_at DESC')
   end
 
   # GET /feed.rss
   def feed
-    @recognitions = Recognition.all.order(:created_at).reverse_order.first(15)
+    @recognitions = Recognition.all.order('created_at DESC').first(15)
     respond_to do |format|
       format.rss { render layout: false }
     end


### PR DESCRIPTION
Fixes #89 

#### Local Checklist
- [x] Tests passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?

#### What does this PR do?
Switches the recognition `index` action to sort reverse chronologically. the `feed` action was already doing this, so the two were lined up as far as the way the query is constructed.

##### Why are we doing this? Any context of related work?
References #89 

@VivianChu  - please review
