### PR TITLE
statistics: add description to csv

### DIFF
--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -8,7 +8,7 @@ module StatisticsHelper
   # @param results
   # @return [String] csv of results
   def generate_csv(results)
-    attributes = %w[Reconizee Recognizer Value Anonymous Opted-Out Submitted]
+    attributes = %w[Reconizee Recognizer Value Description Anonymous Opted-Out Submitted]
 
     CSV.generate(headers: true) do |csv|
       csv << attributes
@@ -23,9 +23,10 @@ module StatisticsHelper
     nominee = recognition.employee.display_name
     nominator = recognition.user.full_name
     value = LIBRARY_VALUES[recognition.library_value]
+    description = recognition.description
     anonymous = recognition.anonymous
     suppressed = recognition.suppressed
     submitted = recognition.created_at
-    [nominee, nominator, value, anonymous, suppressed, submitted]
+    [nominee, nominator, value, description, anonymous, suppressed, submitted]
   end
 end

--- a/spec/controllers/statistics_controller_spec.rb
+++ b/spec/controllers/statistics_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe StatisticsController, type: :controller do
                                                   employee: employee) }
       let(:employee) { FactoryBot.create(:employee) }
       let(:user) { FactoryBot.create(:user) }
-      let(:csv_string) { "Reconizee,Recognizer,Value,Anonymous,Opted-Out,Submitted\nMyString,Jane Triton,Collaboration and Communication,false,false,2018-10-01 00:00:00 UTC\n" }
+      let(:csv_string) { "Reconizee,Recognizer,Value,Description,Anonymous,Opted-Out,Submitted\nMyString,Jane Triton,Collaboration and Communication,in report,false,false,2018-10-01 00:00:00 UTC\n" }
       let(:csv_options) { {:filename=>"highfive-stats-2018-10-01-2018-10-15.csv"} }
 
       before do


### PR DESCRIPTION
Fixes #93 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?

#### What does this PR do?
Adds the description field to the generated CSV for statistics.

##### Why are we doing this? Any context of related work?
References #93 

@VivianChu  - please review
