### PR TITLE
recognition form: sort employees in select list

### DIFF
--- a/app/views/recognitions/_form.html.erb
+++ b/app/views/recognitions/_form.html.erb
@@ -1,6 +1,7 @@
 <%= simple_form_for(@recognition) do |f| %>
   <%= f.association :employee,
               label_method: :display_name,
+              collection: Employee.order(:display_name),
               prompt: 'Select employee to recognize' %>
 
   <%= f.input :library_value,

--- a/spec/system/recognition_spec.rb
+++ b/spec/system/recognition_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe 'interacting with recognitions', type: :system do
     expect(page).to have_current_path(recognitions_path)
   end
 
+  it 'sorts the employees by display name in the select list' do
+    sign_in
+    FactoryBot.create(:employee, display_name: 'Lincoln, Abraham')
+    FactoryBot.create(:employee, display_name: 'Washington, George')
+    FactoryBot.create(:employee, display_name: 'Adams, John')
+    visit new_recognition_path
+    expect(page.find_field('recognition_employee_id').text).to eq "Select employee to recognize Adams, John Lincoln, Abraham Washington, George"
+  end
+
   it 'does not allow a user to create a recognition without a recognizee, value, and description' do
     sign_in
     mock_employee_query


### PR DESCRIPTION
Fixes #102 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?

#### What does this PR do?
Sorts employees in the select list by display name.

##### Why are we doing this? Any context of related work?
The default sort is by pk, which means a completely random list that would be confusing for users.

@VivianChu  - please review
