### PR TITLE
ldap: add whenChanged attribute to employees query

### DIFF
--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -12,13 +12,9 @@ class Employee < ApplicationRecord
   # @param [Net::LDAP::Entry] employee_info
   def self.populate_from_ldap(employee_info)
     e = find_or_initialize_by(uid: employee_info.cn.first)
-    e.display_name = employee_info.displayname.first
-    e.email = employee_info.mail.first
-    e.manager = employee_info.manager.first
-    e.name = "#{employee_info.givenName.first} #{employee_info.sn.first}"
-    e.save
-    # try saving thumbnail as well
-    cache_employee_photo(employee_info)
+    return unless needs_update?(e, String(employee_info.whenChanged.first))
+
+    update_employee_from_ldap(e, employee_info)
   end
 
   # Given an Net::LDAP::Entry store the employee photo if available
@@ -28,5 +24,28 @@ class Employee < ApplicationRecord
 
     image_path = Rails.root.join('app', 'assets', 'images', 'photos', "#{employee_info.cn.first}.jpg")
     IO.write(image_path.to_s, employee_info.thumbnailphoto.first, mode: 'wb')
+  end
+
+  # Update a new, or existing, Employee with the employee info from LDAP
+  def self.update_employee_from_ldap(employee, employee_info)
+    employee.display_name = employee_info.displayname.first
+    employee.email = employee_info.mail.first
+    employee.manager = employee_info.manager.first
+    employee.name = "#{employee_info.givenName.first} #{employee_info.sn.first}"
+    employee.save
+    # try saving thumbnail as well
+    cache_employee_photo(employee_info)
+  end
+
+  # If an employee already exists in our local database,
+  # and the local database modified time is younger then the ldap modified time,
+  # then we can skip updating that record.
+  # @param [Employee] current employee to check for update needs
+  # @param [String] last updated date from ldap. Example. "20181127172427.0Z"
+  def self.needs_update?(employee, ldap_last_updated)
+    return true unless employee.id # new records get updates always
+    return true if Time.zone.parse(ldap_last_updated) > employee.updated_at
+
+    false
   end
 end

--- a/app/services/ldap/queries.rb
+++ b/app/services/ldap/queries.rb
@@ -35,7 +35,7 @@ module Ldap
       ldap_connection.search(
         filter: Ldap::Filters.employees,
         return_result: false,
-        attributes: %w[DisplayName CN mail manager givenName sn Thumbnailphoto]
+        attributes: %w[DisplayName CN mail manager givenName sn Thumbnailphoto whenChanged]
       ) do |employee|
         Employee.populate_from_ldap(employee)
       end

--- a/spec/services/ldap/queries_spec.rb
+++ b/spec/services/ldap/queries_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe Ldap::Queries, type: :service do
       entry1['sn'] = ['Employee']
       entry1['mail'] = ['aemployee@ucsd.edu']
       entry1['manager'] = ['boss1@ucsd.edu']
+      entry1['whenChanged'] = ['20181130172427.0Z']
       entry2 = Net::LDAP::Entry.new('CN=zbestemployee,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU')
       entry2['cn'] = 'zbestemployee'
       entry2['displayName'] = ["Zbestemployee, The"]
@@ -59,6 +60,7 @@ RSpec.describe Ldap::Queries, type: :service do
       entry2['sn'] = ['Zbestemployee']
       entry2['mail'] = ['zbestemployee@ucsd.edu']
       entry2['manager'] = ['boss2@ucsd.edu']
+      entry2['whenChanged'] = ['20181130172427.0Z']
       mock_ldap_validation
       allow(mock_ldap_connection).to receive(:search).and_yield(entry1).and_yield(entry2)
     end


### PR DESCRIPTION
whenChanged can be used to determine whether we need to update a given
local Employee record with data from that employee's LDAP record. This
should save some cycles for the nightly update script and give us more
accurate change tracking over time.

Fixes #110 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?

#### What does this PR do?
Adds a check when updating local Employee records from LDAP to ensure we only do DB writes when necessary.

##### Why are we doing this? Any context of related work?
References #110 

#### Where should a reviewer start?
Tests and implementation of `needs_update?`

@VivianChu - please review