### PR TITLE
photos: remove from application

### DIFF
--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -17,15 +17,6 @@ class Employee < ApplicationRecord
     update_employee_from_ldap(e, employee_info)
   end
 
-  # Given an Net::LDAP::Entry store the employee photo if available
-  # @param [Net::LDAP::Entry] employee_info
-  def self.cache_employee_photo(employee_info)
-    return unless employee_info.respond_to?(:thumbnailphoto)
-
-    image_path = Rails.root.join('app', 'assets', 'images', 'photos', "#{employee_info.cn.first}.jpg")
-    IO.write(image_path.to_s, employee_info.thumbnailphoto.first, mode: 'wb')
-  end
-
   # Update a new, or existing, Employee with the employee info from LDAP
   def self.update_employee_from_ldap(employee, employee_info)
     employee.display_name = employee_info.displayname.first
@@ -33,8 +24,6 @@ class Employee < ApplicationRecord
     employee.manager = employee_info.manager.first
     employee.name = "#{employee_info.givenName.first} #{employee_info.sn.first}"
     employee.save
-    # try saving thumbnail as well
-    cache_employee_photo(employee_info)
   end
 
   # If an employee already exists in our local database,

--- a/app/services/ldap/queries.rb
+++ b/app/services/ldap/queries.rb
@@ -35,7 +35,7 @@ module Ldap
       ldap_connection.search(
         filter: Ldap::Filters.employees,
         return_result: false,
-        attributes: %w[DisplayName CN mail manager givenName sn Thumbnailphoto whenChanged]
+        attributes: %w[DisplayName CN mail manager givenName sn whenChanged]
       ) do |employee|
         Employee.populate_from_ldap(employee)
       end

--- a/app/views/recognitions/index.html.erb
+++ b/app/views/recognitions/index.html.erb
@@ -10,7 +10,7 @@
 <table class='table'>
   <thead class="thead-light">
     <tr>
-      <th scope="col" colspan=2>Recognizee</th>
+      <th scope="col">Recognizee</th>
       <th scope="col">Library value</th>
       <th scope="col">Description</th>
       <th scope="col">Anonymous</th>
@@ -23,11 +23,6 @@
     <% @recognitions.each do |recognition| %>
       <tr>
         <td><%= recognition.employee.display_name %></td>
-        <% if(File.file?("app/assets/images/photos/#{recognition.employee.uid}.jpg")) %>
-        <td><%= image_tag("photos/#{recognition.employee.uid}.jpg") %></td>
-        <% else %>
-        <td></td>
-        <% end %>
         <td><%= LIBRARY_VALUES[ recognition.library_value ] %></td>
         <td><%= recognition.description %></td>
         <td><%= recognition.anonymous ? 'Anonymous' : 'No' %></td>

--- a/app/views/recognitions/show.html.erb
+++ b/app/views/recognitions/show.html.erb
@@ -1,6 +1,3 @@
-<% if(File.file?("app/assets/images/photos/#{@recognition.employee.uid}.jpg")) %>
-<p><%= image_tag("photos/#{@recognition.employee.uid}.jpg") %></p>
-<% end %>
 <p>
   <strong>Recognizee:</strong>
   <%= @recognition.employee.display_name %>

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -66,34 +66,4 @@ RSpec.describe Employee, type: :model do
       expect(Employee.first.display_name).to eq('Batman')
     end
   end
-
-  describe '.cache_employee_photo' do
-    let(:entry1) { Net::LDAP::Entry.new('CN=aemployee,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU') }
-    before do
-      entry1['cn'] = 'aemployee'
-      entry1['displayName'] = ['Employee, A']
-      entry1['givenName'] = ['A']
-      entry1['sn'] = ['Employee']
-      entry1['mail'] = ['aemployee@ucsd.edu']
-      entry1['manager'] = ['boss1@ucsd.edu']
-      entry1['whenChanged'] = ['20181127172427.0Z']
-    end
-    context 'without an ldap photo' do
-      it 'should not write to photos directory' do
-        expect(described_class.cache_employee_photo(entry1)).to be_nil
-      end
-    end
-
-    context 'with an ldap photo' do
-      after do
-        system("rm -rf #{Rails.root}/app/assets/images/photos/aemployee.jpg")
-      end
-      it 'should write to photos directory' do
-        entry1['Thumbnailphoto'] = '/9j/4AAQSkZJRgABAQEAAQABAAD//2gAIAQEAAD8AVN//2Q=='
-        described_class.cache_employee_photo(entry1)
-        expect(File.file?("#{Rails.root}/app/assets/images/photos/aemployee.jpg")).to be true
-      end
-    end
-
-  end
 end


### PR DESCRIPTION
it turns out AD isn't a reliable, single source of record for employee
photos. since we don't have one, we're pulling the feature, for now

Fixes #114 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?

#### What does this PR do?
Remove the AD photo feature.

##### Why are we doing this? Any context of related work?
References #114 

@VivianChu  - please review
