### PR TITLE
Feature/active employee

### DIFF
--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -7,6 +7,10 @@ class Employee < ApplicationRecord
 
   validates :uid, :email, :manager, :display_name, :name, presence: true
 
+  # custom scopes
+  scope :sort_by_name, -> { order(:display_name) }
+  scope :active_employees, -> { where(active: true).sort_by_name }
+
   # Given an Net::LDAP::Entry extract and populate an Employee record
   # using the cn/uid as the unique key
   # @param [Net::LDAP::Entry] employee_info

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -41,4 +41,16 @@ class Employee < ApplicationRecord
 
     false
   end
+
+  # Takes a current listing of employees from the Ldap::Queries.employees query and compares it to the listing in the
+  # Employee database. If there are employees in database that are NOT in the ldap response, we need to mark them
+  # inactive under the assumption they no longer work for the library
+  # @param [Array] employees where each entry is the uid of a given employee
+  def self.update_status_for_all(employees)
+    (Employee.pluck(:uid) - employees).each do |employee_uid|
+      employee_to_deactivate = Employee.find_by(uid: employee_uid)
+      employee_to_deactivate.active = false
+      employee_to_deactivate.save
+    end
+  end
 end

--- a/app/services/ldap/queries.rb
+++ b/app/services/ldap/queries.rb
@@ -30,17 +30,21 @@ module Ldap
     end
 
     # Query all currently active employees
-    # @return [Array] employee information to populate Employees table
+    # rubocop:disable Metrics/MethodLength
     def self.employees
+      current_employees = []
       ldap_connection.search(
         filter: Ldap::Filters.employees,
         return_result: false,
         attributes: %w[DisplayName CN mail manager givenName sn whenChanged]
       ) do |employee|
         Employee.populate_from_ldap(employee)
+        current_employees << employee.cn.first
       end
+      Employee.update_status_for_all(current_employees)
       validate_ldap_response
     end
+    # rubocop:enable Metrics/MethodLength
 
     # Given a UID/CN determine whether a user is a library staff member using #employees filter
     # @param uid [String] the user id to check. e.g. 'drseuss'

--- a/app/views/recognitions/_form.html.erb
+++ b/app/views/recognitions/_form.html.erb
@@ -1,7 +1,7 @@
 <%= simple_form_for(@recognition) do |f| %>
   <%= f.association :employee,
               label_method: :display_name,
-              collection: Employee.order(:display_name),
+              collection: Employee.active_employees,
               prompt: 'Select employee to recognize' %>
 
   <%= f.input :library_value,

--- a/db/migrate/20181130213626_add_active_to_employees.rb
+++ b/db/migrate/20181130213626_add_active_to_employees.rb
@@ -1,0 +1,5 @@
+class AddActiveToEmployees < ActiveRecord::Migration[5.2]
+  def change
+    add_column :employees, :active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_09_225636) do
+ActiveRecord::Schema.define(version: 2018_11_30_213626) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2018_11_09_225636) do
     t.string "display_name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "active", default: true
   end
 
   create_table "opt_out_links", force: :cascade do |t|

--- a/spec/factories/employees.rb
+++ b/spec/factories/employees.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     sequence(:uid) { |n| "employee#{n}" }
     sequence(:email) { |n| "employee#{n}@ucsd.edu" }
     name { "MyString" }
+    active { true }
     sequence(:manager) { |n| "CN=employee#{n-1},OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU" }
     display_name { "MyString" }
   end

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe Employee, type: :model do
     end
   end
 
+  describe '.active_employees' do
+    let!(:active_employee) { FactoryBot.create(:employee, active: true, display_name: 'active employee') }
+    let!(:inactive_employee) { FactoryBot.create(:employee, active: false, display_name: 'inactive employee') }
+    it 'only includes currently active employees' do
+      expect(described_class.active_employees.map(&:display_name)).to eq(['active employee'])
+    end
+  end
+
   describe '.populate_from_ldap' do
     let(:entry1) { Net::LDAP::Entry.new('CN=aemployee,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU') }
     before do

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -52,6 +52,19 @@ RSpec.describe Employee, type: :model do
     end
   end
 
+  describe '.update_status_for_all' do
+    let!(:active_employee1) { FactoryBot.create(:employee, active: true, display_name: 'active employee') }
+    let!(:active_employee2) { FactoryBot.create(:employee, active: true, display_name: 'active employee 2') }
+    let!(:employee_to_deactivate) { FactoryBot.create(:employee, active: true, display_name: 'inactive employee') }
+    it 'deactives employees who are no longer in ldap OU' do
+      active_employees = [active_employee1.uid, active_employee2.uid]
+      described_class.update_status_for_all(active_employees)
+
+      expect(described_class.active_employees.map(&:display_name)).to eq(['active employee', 'active employee 2'])
+    end
+
+  end
+
   describe '.populate_from_ldap' do
     let(:entry1) { Net::LDAP::Entry.new('CN=aemployee,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU') }
     before do

--- a/spec/system/recognition_spec.rb
+++ b/spec/system/recognition_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe 'interacting with recognitions', type: :system do
     expect(page).to have_current_path(recognitions_path)
   end
 
+  it 'does not display inactive employees in the select list' do
+    sign_in
+    FactoryBot.create(:employee, display_name: 'Lincoln, Abraham')
+    FactoryBot.create(:employee, active: false, display_name: 'Washington, George')
+    FactoryBot.create(:employee, display_name: 'Adams, John')
+    visit new_recognition_path
+    expect(page.find_field('recognition_employee_id').text).to eq "Select employee to recognize Adams, John Lincoln, Abraham"
+
+  end
+
   it 'sorts the employees by display name in the select list' do
     sign_in
     FactoryBot.create(:employee, display_name: 'Lincoln, Abraham')


### PR DESCRIPTION
Fixes #104 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [x] Documentation updated (if needed)?

#### What does this PR do?
Please see the commit messages for each piece. Essentially we're adding an `active` boolean property to the `Employee` table (which defaults to `true`). When we find, via our LDAP employee query, that an employee no longer shows up in the query results that we have an Employee record for, we set that employee to be inactive `active = false`. 

To support using this in the form, I added a couple scopes to the Employee table.

##### Why are we doing this? Any context of related work?
References #104 

#### Where should a reviewer start?
I would start with the oldest commit (the database migration) and move forward up to the commit with the ldap integration.

@VivianChu  - please review, @dt-ucsd FYI
