### PR TITLE
employee: only persist manager CN from dn

### DIFF
--- a/app/mailers/recognition_mailer.rb
+++ b/app/mailers/recognition_mailer.rb
@@ -16,9 +16,8 @@ class RecognitionMailer < ApplicationMailer
     @key = optout_obj ? optout_obj.key : Recognition.new.generate_key(id)
   end
 
-  def manager_email(manager_dn)
-    uid = manager_dn.split(',').first.gsub('CN=', '')
-    manager = Employee.find_by(uid: uid)
+  def manager_email(manager_uid)
+    manager = Employee.find_by(uid: manager_uid)
     return manager.email if manager
   end
 end

--- a/spec/factories/employees.rb
+++ b/spec/factories/employees.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     sequence(:email) { |n| "employee#{n}@ucsd.edu" }
     name { "MyString" }
     active { true }
-    sequence(:manager) { |n| "CN=employee#{n-1},OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU" }
+    sequence(:manager) { |n| "manager#{n}" }
     display_name { "MyString" }
   end
 end

--- a/spec/mailers/recognition_mailer_spec.rb
+++ b/spec/mailers/recognition_mailer_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe RecognitionMailer do
                                                  created_at: Time.parse('2018-10-01'),
                                                  description: 'in report',
                                                  employee: employee) }
-  let(:employee) { FactoryBot.create(:employee) }
+  let(:employee) { FactoryBot.create(:employee, manager: manager.uid) }
   let(:user) { FactoryBot.build_stubbed(:user) }
   let(:email) {RecognitionMailer.email(recognition)}
   before do
     mock_email_credential
   end
-      
+
   it 'renders the subject' do
     expect(email.subject).to eql("You have been recognized!")
   end
@@ -23,20 +23,20 @@ RSpec.describe RecognitionMailer do
   it 'renders the receiver email' do
     expect(email.to).to eql([employee.email, manager.email])
   end
-  
+
   it 'renders the sender email' do
     expect(email.from).to eql(['developer@ucsd.edu'])
   end
- 
+
   it 'assigns recognition name, library value, and description' do
     expect(email.body.encoded).to match("Dear #{recognition.employee.name},")
     expect(email.body.encoded).to match(LIBRARY_VALUES[recognition.library_value])
     expect(email.body.encoded).to match(recognition.user.full_name)
     expect(email.body.encoded).to match(recognition.description)
-  end 
+  end
 
   it 'assigns recognition url' do
     url = "/recognitions/#{recognition.id}"
     expect(email.body.encoded).to match(url)
-  end    
+  end
 end

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Employee, type: :model do
       entry['givenName'] = ['A']
       entry['sn'] = ['Employee']
       entry['mail'] = ['aemployee@ucsd.edu']
-      entry['manager'] = ['boss1@ucsd.edu']
+      entry['manager'] = ['CN=bigboss1,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU']
       entry['whenChanged'] = ['20181127172427.0Z']
     end
 
@@ -73,7 +73,7 @@ RSpec.describe Employee, type: :model do
       entry1['givenName'] = ['A']
       entry1['sn'] = ['Employee']
       entry1['mail'] = ['aemployee@ucsd.edu']
-      entry1['manager'] = ['boss1@ucsd.edu']
+      entry1['manager'] = ['CN=bigboss1,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU']
       entry1['whenChanged'] = ['20181127172427.0Z']
     end
 

--- a/spec/services/ldap/queries_spec.rb
+++ b/spec/services/ldap/queries_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Ldap::Queries, type: :service do
       entry1['givenName'] = ['A']
       entry1['sn'] = ['Employee']
       entry1['mail'] = ['aemployee@ucsd.edu']
-      entry1['manager'] = ['boss1@ucsd.edu']
+      entry1['manager'] = ['CN=bigboss1,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU']
       entry1['whenChanged'] = ['20181130172427.0Z']
       entry2 = Net::LDAP::Entry.new('CN=zbestemployee,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU')
       entry2['cn'] = 'zbestemployee'
@@ -59,7 +59,7 @@ RSpec.describe Ldap::Queries, type: :service do
       entry2['givenName'] = ['The']
       entry2['sn'] = ['Zbestemployee']
       entry2['mail'] = ['zbestemployee@ucsd.edu']
-      entry2['manager'] = ['boss2@ucsd.edu']
+      entry2['manager'] = ['CN=bigboss2,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU']
       entry2['whenChanged'] = ['20181130172427.0Z']
       mock_ldap_validation
       allow(mock_ldap_connection).to receive(:search).and_yield(entry1).and_yield(entry2)


### PR DESCRIPTION
Fixes #124 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [x] Documentation updated (if needed)?

#### What does this PR do?
Instead of persisting the entire DN value from the ldap `manager` field, we only persist the CN. @VivianChu was already parsing this out to send emails, and we should just store it in the DB this way to keep things simple.

##### Why are we doing this? Any context of related work?
References #124 

@VivianChu  - please review
