### PR TITLE
recognitions: add temp link on landing page

### DIFF
--- a/app/views/recognitions/front.html.erb
+++ b/app/views/recognitions/front.html.erb
@@ -2,6 +2,10 @@
   <strong>Welcome to High Five!</strong>
 </p>
 
+<p>
+  <%= link_to 'View Recognitions', recognitions_path, class: "btn btn-outline-primary"%>
+</p>
+
 <% if current_user && (current_user.developer? || valid_administrator?) %>
 <p>
 <%= link_to 'Generate Statistics', statistics_path, class: "btn btn-outline-primary"%>


### PR DESCRIPTION
Fixes #137

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?

#### What does this PR do?

Adds a temporary link on the landing page to recognitions for the testing group. It is assumed this will be removed later once we have a proper UI setup.

##### Why are we doing this? Any context of related work?
References #137

@VivianChu - please review
