### PR TITLE
email: add recognizer to the To: receiver list

### DIFF
--- a/app/mailers/recognition_mailer.rb
+++ b/app/mailers/recognition_mailer.rb
@@ -5,10 +5,16 @@ class RecognitionMailer < ApplicationMailer
   def email(recognition)
     @recognition = recognition
     opt_out_key(recognition.id)
-    mail(to: "#{@recognition.employee.email},#{manager_email(@recognition.employee.manager)}",
+    mail(to: mail_to_group,
          from: Rails.application.credentials.email[:sender],
          bcc: Rails.application.credentials.email[:bcc],
          subject: 'You have been recognized!')
+  end
+
+  def mail_to_group
+    [@recognition.employee.email,
+     manager_email(@recognition.employee.manager),
+     @recognition.user.email].join(',')
   end
 
   def opt_out_key(id)

--- a/spec/mailers/recognition_mailer_spec.rb
+++ b/spec/mailers/recognition_mailer_spec.rb
@@ -21,7 +21,11 @@ RSpec.describe RecognitionMailer do
   end
 
   it 'renders the receiver email' do
-    expect(email.to).to eql([employee.email, manager.email])
+    expect(email.to).to eql([employee.email, manager.email, user.email])
+  end
+
+  it 'sends the recognizer a copy of the email' do
+    expect(email.to).to include(user.email)
   end
 
   it 'renders the sender email' do


### PR DESCRIPTION
Fixes #155 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?

#### What does this PR do?

Adds the recognizer to the list of people in the `To:` field for the recognition email.

##### Why are we doing this? Any context of related work?
References #155 

@VivianChu  - please review
