### PR TITLE
whenever: fix incorrect syntax causing midnight entries

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,11 +1,13 @@
 set :output, { error: "log/cron_error.log", standard: "log/cron_standard.log" }
+# potentially use this for prod?
+# set :output, lambda { "2>&1 | logger -t high_five_cron" }
 #
 # Update the Employee table
-every 1.day at: '3:00 am' do
+every 1.day, at: '3:00 am' do
   rake "nightly:employees"
 end
 
 # Remove expired OptOutLinks
-every 1.day at: '2:00 am' do
+every 1.day, at: '2:00 am' do
   rake "nightly:expire_links"
 end


### PR DESCRIPTION

#### What does this PR do?

There was a syntax error in defining the cron entries using whenever. Those commas add up..

Also putting in an option we might want to use for production, we'll sort that out w/ Ron separately.

@VivianChu  - please review
