### PR TITLE
employee: don't deactivate deactivated employees

### DIFF
--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -62,7 +62,7 @@ class Employee < ApplicationRecord
   # inactive under the assumption they no longer work for the library
   # @param [Array] employees where each entry is the uid of a given employee
   def self.update_status_for_all(employees)
-    (Employee.pluck(:uid) - employees).each do |employee_uid|
+    (Employee.active_employees.pluck(:uid) - employees).each do |employee_uid|
       Rails.logger.tagged('employee', 'deactivate') { Rails.logger.error "deactivating employee: #{employee_uid}" }
       employee_to_deactivate = Employee.find_by(uid: employee_uid)
       employee_to_deactivate.active = false

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -53,16 +53,24 @@ RSpec.describe Employee, type: :model do
   end
 
   describe '.update_status_for_all' do
-    let!(:active_employee1) { FactoryBot.create(:employee, active: true, display_name: 'active employee') }
-    let!(:active_employee2) { FactoryBot.create(:employee, active: true, display_name: 'active employee 2') }
-    let!(:employee_to_deactivate) { FactoryBot.create(:employee, active: true, display_name: 'inactive employee') }
     it 'deactives employees who are no longer in ldap OU' do
+      active_employee1 =  FactoryBot.create(:employee, active: true, display_name: 'active employee')
+      active_employee2 =  FactoryBot.create(:employee, active: true, display_name: 'active employee 2')
+      employee_to_deactivate =  FactoryBot.create(:employee, active: true, display_name: 'inactive employee')
       active_employees = [active_employee1.uid, active_employee2.uid]
       described_class.update_status_for_all(active_employees)
 
       expect(described_class.active_employees.map(&:display_name)).to eq(['active employee', 'active employee 2'])
     end
 
+    it 'does not try deactivating already deactivated employees' do
+      active_employee =  FactoryBot.create(:employee, active: true, display_name: 'active employee')
+      deactivated_employee =  FactoryBot.create(:employee, active: false, display_name: 'inactive employee')
+      active_employees = [active_employee.uid]
+
+      expect(Rails.logger).to_not receive(:error).with(anything)
+      described_class.update_status_for_all(active_employees)
+    end
   end
 
   describe '.populate_from_ldap' do


### PR DESCRIPTION
#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?

#### What does this PR do?
While we were successfully deactivating employees with the nightly cron
tasks, we were forgetting to ignore those deactivated employees in the
filter query

@VivianChu  - please review
