### PR TITLE
Capistrano prod prep

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -6,29 +6,7 @@ require "capistrano/deploy"
 require "capistrano/scm/git"
 install_plugin Capistrano::SCM::Git
 
-# Load the SCM plugin appropriate to your project:
-#
-# require "capistrano/scm/hg"
-# install_plugin Capistrano::SCM::Hg
-# or
-# require "capistrano/scm/svn"
-# install_plugin Capistrano::SCM::Svn
-# or
-
-# Include tasks from other gems included in your Gemfile
-#
-# For documentation on these, see for example:
-#
-#   https://github.com/capistrano/rvm
-#   https://github.com/capistrano/rbenv
-#   https://github.com/capistrano/chruby
-#   https://github.com/capistrano/bundler
-#   https://github.com/capistrano/rails
-#   https://github.com/capistrano/passenger
-#
-# require "capistrano/rvm"
 require "capistrano/rbenv"
-# require "capistrano/chruby"
 require "capistrano/bundler"
 # require "capistrano/rails/assets"
 require "capistrano/rails/migrations"

--- a/app/views/recognition_mailer/email.html.erb
+++ b/app/views/recognition_mailer/email.html.erb
@@ -1,6 +1,6 @@
 <html lang="en">
   <body>
-<% 
+<%
   lisn_url = 'https://library.ucsd.edu/lisn'
 %>
      <p>Dear <%= @recognition.employee.name %>,</p><br/>
@@ -10,13 +10,13 @@
 
      <p>Please see the recognition below:</>
 
-     <p><i><%= @recognition.description %></i></p> 
+     <p><i><%= @recognition.description %></i></p>
 
      <p>This recognition can also be viewed on the homepage of LiSN
      (<%= link_to lisn_url, lisn_url%>)
      or by going directly to the post: <%= link_to recognition_url(@recognition), recognition_url(@recognition) %></p>
 
-     <p>If for some reason you do not want your recognition to appear, or would like it removed from LiSN, 
+     <p>If for some reason you do not want your recognition to appear, or would like it removed from LiSN,
      please click this link to opt-out: <%= link_to optout_url(@key), optout_url(@key) %> </p><br/>
 
 
@@ -24,6 +24,6 @@
 
      <p>High Five! Employee Recognition Program<br/>
         UC San Diego Library<br/>
-        https://library.ucsd.edu/h5</p>     
+        <a href="<%= root_url %>"><%= root_url %></a></p>
   </body>
 </html>

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 set :stage, :production
 set :branch, (ENV['BRANCH'] || fetch(:branch, 'master'))
-server 'lib-hydrahead-prod.ucsd.edu', user: 'conan', roles: %w{web app db}
+server 'lib-highfive.ucsd.edu', user: 'conan', roles: %w{web app db}
 set :rails_env, 'production'
 if ENV['CAP_SSHKEY_PRODUCTION']
   puts "Using key: #{File.join(ENV["HOME"], ENV["CAP_SSHKEY_PRODUCTION"])}"

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 set :stage, :staging
 set :branch, (ENV['BRANCH'] || fetch(:branch, 'master'))
-server 'lib-hifive-staging.ucsd.edu', user: 'conan', roles: %w{web app db sitemap_noping}
+server 'lib-hifive-staging.ucsd.edu', user: 'conan', roles: %w{web app db}
 set :rails_env, 'staging'
 if ENV['CAP_SSHKEY_STAGING']
   puts "Using key: #{File.join(ENV["HOME"], ENV["CAP_SSHKEY_STAGING"])}"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,7 +95,6 @@ Rails.application.configure do
   logger.formatter = config.log_formatter
   config.logger    = ActiveSupport::TaggedLogging.new(logger)
 
-
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,7 +72,7 @@ Rails.application.configure do
 
   config.action_mailer.raise_delivery_errors = true
 
-  config.action_mailer.default_url_options = {host: 'library.ucsd.edu'}
+  config.action_mailer.default_url_options = {host: 'lib-highfive.ucsd.edu'}
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
Fixes: #170 
...and some of #169 

#### Local Checklist
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?

#### What does this PR do?
- Removes hard-coded /h5 URL and replaces w/ `root_url`
- Sets `lib-highfive.ucsd.edu` as host for action mailer (email)
- Adds capistrano production server to config file
- Remove the sitemap role from staging config (presumably copy/paste from somewhere)
- Remove some extraneous comments in Capfile

##### Why are we doing this? Any context of related work?
References #169 #170 

@VivianChu  - please review
