### PR TITLE
Capistrano relative fix

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,6 +1,6 @@
 # config valid for current version and patch releases of Capistrano
 set :application, "hifive"
-set :repo_url, "git@github.com:ucsdlib/hifive.git"
+set :repo_url, "https://github.com/ucsdlib/hifive.git"
 
 set :deploy_to, '/pub/hifive'
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,7 +25,7 @@ namespace :deploy do
       on roles(:web) do
         within release_path do
           with rails_env: fetch(:rails_env) do
-            execute :rake, 'RAILS_RELATIVE_URL_ROOT=/hifive assets:precompile'
+            execute :rake, 'assets:precompile'
           end
         end
       end


### PR DESCRIPTION
#### Local Checklist
- [x] Rebased with `master` branch?
- [x] Configuration updated (if needed)?

#### What does this PR do?
- Switches capistrano repo URL to https, apparently there may be ssh keys missing somewhere, and since this is a public repo doesn't seem like it matters.
- Remove `RAILS_RELATIVE_URL_ROOT` when compiling assets. We're not hosting the app off a subdirectory

##### Why are we doing this? Any context of related work?
References #169 

@VivianChu @jhriv  - please review
