### PR TITLE
capistrano: deploy to the /pub/highfive directory

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,7 @@
 set :application, "hifive"
 set :repo_url, "https://github.com/ucsdlib/hifive.git"
 
-set :deploy_to, '/pub/hifive'
+set :deploy_to, '/pub/highfive'
 
 # rails
 # rails migrations are related to the framework/app


### PR DESCRIPTION
#### Local Checklist
- [x] Rebased with `master` branch?
- [x] Configuration updated (if needed)?

#### What does this PR do?
Always deploy to `/pub/highfive` for staging and prod

##### Why are we doing this? Any context of related work?
References #169 

@VivianChu @rstanonik  - please review
