### PR TITLE
gems: add pry-rails and pry-doc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ group :development, :test do
   gem 'capybara'
   gem 'coveralls'
   gem 'factory_bot_rails'
+  gem 'pry-rails'
+  gem 'pry-doc'
   gem 'rspec-rails'
   gem 'rubocop'
   gem 'rubocop-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -168,6 +169,14 @@ GEM
     pg (1.1.4)
     popper_js (1.14.5)
     powerpack (0.1.2)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-doc (1.0.0)
+      pry (~> 0.11)
+      yard (~> 0.9.11)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
@@ -305,6 +314,7 @@ GEM
       chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.18)
 
 PLATFORMS
   ruby
@@ -330,6 +340,8 @@ DEPENDENCIES
   omniauth
   omniauth-shibboleth
   pg (>= 0.18, < 2.0)
+  pry-doc
+  pry-rails
   puma (~> 3.11)
   rails (~> 5.2.2)
   rspec-rails
@@ -348,7 +360,7 @@ DEPENDENCIES
   whenever
 
 RUBY VERSION
-   ruby 2.5.3p105
+   ruby 2.6.0p0
 
 BUNDLED WITH
-   1.16.6
+   1.17.2


### PR DESCRIPTION
This provides a better rails console that we can use for local debugging
and testing. It provides much richer information than the standard
IRB/Rails console.

For example:
```
[8] pry(main)> Recognition.new.method(:generate_link).source.display
  def generate_link
    logger.tagged('recognition') { logger.info "sending email for recognition #{id}" }
    generate_key(id)
    RecognitionMailer.email(Recognition.find(id)).deliver_now
  end
=> nil
```

See:
- https://github.com/pry/pry#introduction
- https://github.com/rweng/pry-rails#usage

#### Local Checklist
- [x] QA-ed locally?
- [x] Rebased with `master` branch?

@VivianChu  - please review
