### PR TITLE
docker: support selenium testing

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,72 +1,20 @@
-FROM ruby:2.6.1
+FROM ruby:2.6.1-alpine
 
-# Install current nodejs
-# gpg keys listed at https://github.com/nodejs/node#release-team
-RUN set -ex \
-  && for key in \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-    56730D5401028683275BD23C23EFEFE93C4CFFFE \
-    77984A986EBC2AA786BC0F66B01FBB92821C587A \
-    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
-  ; do \
-    gpg --no-tty --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --no-tty --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --no-tty --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
-  done
+RUN apk --no-cache upgrade && \
+  apk add --no-cache \
+  build-base \
+  postgresql-dev \
+  nodejs \
+  nodejs-npm \
+  tzdata
 
-ENV NODE_VERSION 10.14.2
+RUN addgroup -g 1000 -S theodor && \
+    adduser -u 1000 -S theodor -G theodor
+USER theodor
 
-RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
-  && case "${dpkgArch##*-}" in \
-    amd64) ARCH='x64';; \
-    ppc64el) ARCH='ppc64le';; \
-    s390x) ARCH='s390x';; \
-    arm64) ARCH='arm64';; \
-    armhf) ARCH='armv7l';; \
-    i386) ARCH='x86';; \
-    *) echo "unsupported architecture"; exit 1 ;; \
-  esac \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-  && gpg --no-tty --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
-  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
-
-# Install Chrome
-RUN set -ex \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" \
-        >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update -qqy \
-    && apt-get -qqy install google-chrome-stable unzip \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Chromedriver
-ARG CHROME_DRIVER_VERSION="latest"
-RUN CD_VERSION=$(if [ ${CHROME_DRIVER_VERSION:-latest} = "latest" ]; then echo $(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE); else echo $CHROME_DRIVER_VERSION; fi) \
-  && echo "Using chromedriver version: "$CD_VERSION \
-  && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CD_VERSION/chromedriver_linux64.zip \
-  && rm -rf /opt/selenium/chromedriver \
-  && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium \
-  && rm /tmp/chromedriver_linux64.zip \
-  && mv /opt/selenium/chromedriver /opt/selenium/chromedriver-$CD_VERSION \
-  && chmod 755 /opt/selenium/chromedriver-$CD_VERSION \
-  && ln -fs /opt/selenium/chromedriver-$CD_VERSION /usr/bin/chromedriver
-
-ENV BUNDLE_PATH=/bundle \
-    BUNDLE_BIN=/bundle/bin \
-    GEM_HOME=/bundle
-ENV PATH="${BUNDLE_BIN}:${PATH}"
-
-RUN mkdir -p /app
-WORKDIR /app
-COPY Gemfile* ./
+RUN mkdir -p /home/theodor/app
+WORKDIR /home/theodor/app
+COPY --chown=theodor:theodor Gemfile* ./
+RUN gem update bundler
 RUN bundle install --jobs 4 --retry 3
-COPY . ./
+COPY --chown=theodor:theodor . /home/theodor/app/

--- a/bin/docker-helper.sh
+++ b/bin/docker-helper.sh
@@ -40,7 +40,7 @@ if [ "$remove_containers_and_volumes" = "1" ]; then
 fi
 
 if [ "$run_tests" = "1" ]; then
-  docker-compose -f "${compose_env}docker-compose.yml" exec web bundle exec rspec
+  docker-compose -f "./docker/test/docker-compose.yml" build && docker-compose -f "./docker/test/docker-compose.yml" up
 elif [ "$seed_database" = "1" ]; then
   docker-compose -f "${compose_env}docker-compose.yml" exec web bundle exec rake db:seed
 else

--- a/docker/test/docker-compose.yml
+++ b/docker/test/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.6'
+
+services:
+  web:
+    build:
+      context: ../../.
+      dockerfile: Dockerfile.development
+    ports:
+      - "3000:3000"
+    working_dir: /app
+    command: sh -c 'bundle exec rake db:test:prepare && bundle exec rspec'
+    volumes:
+      - ../../.:/app
+    depends_on:
+      - database
+    environment:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres@database
+      SELENIUM_URL: http://browser:4444/wd/hub/
+    stdin_open: true
+    tty: true
+
+  database:
+    image: postgres:10.6-alpine
+    ports:
+      - "5433:5432"
+
+  browser:
+    image: selenium/standalone-chrome:latest
+    ports:
+      - "4444:4444"
+


### PR DESCRIPTION
#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [x] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
- Change Dockerfile.development to use Alpine
- Change Dockerfile.development to NOT install chrome/chromedriver
- Use selenium docker image for docker-compose testing
- Fix capybara/selenium configuration to support docker environment

##### Why are we doing this? Any context of related work?
Previously, in order to do local testing in a docker-compose environment, we had to install Chrome and chromedriver in the Dockerfile/image. Which made the image huge. This PR removes that need by leveraging a selenium image for JS testing instead.

#### Where should a reviewer start?
Please clean out your existing images, and try running the docker test command from the helper script:

` bin/docker-helper.sh -t`

Hopefully this results in passing test suite, if not, please let me know!

#### New ENV variables
`SELENIUM_URL: http://browser:4444/wd/hub/` for testing environment only

@VivianChu  - please review
