### PR TITLE
Use latest version of Bundler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,12 @@ jobs:
       - restore_cache:
           keys:
           - bundle-v1-{{ checksum "Gemfile.lock" }}
-      - run: bundle check || bundle install --path vendor/bundle --jobs 4 --retry 3
+      - run:
+          name: Update Bundler
+          command: gem update bundler
+      - run:
+          name: Run Bundle Install
+          command: bundle check || bundle install --path vendor/bundle --jobs 4 --retry 3
       - save_cache:
           key: bundle-v1-{{ checksum "Gemfile.lock" }}
           paths:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apk --no-cache upgrade && \
 RUN mkdir -p /build-src
 WORKDIR /build-src
 COPY Gemfile* ./
-RUN bundle install --jobs 4 --retry 2
+RUN gem update bundler
+RUN bundle check || bundle install --jobs "$(nproc)" --retry 2
 
 FROM ruby:2.6.2-alpine
 

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -16,5 +16,5 @@ RUN mkdir -p /home/theodor/app
 WORKDIR /home/theodor/app
 COPY --chown=theodor:theodor Gemfile* ./
 RUN gem update bundler
-RUN bundle install --jobs 4 --retry 3
+RUN bundle check || bundle install --jobs "$(nproc)" --retry 2
 COPY --chown=theodor:theodor . /home/theodor/app/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,4 +363,4 @@ RUBY VERSION
    ruby 2.6.2p47
 
 BUNDLED WITH
-   1.17.2
+   2.0.1

--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.6'
+version: '3.7'
 
 services:
   web:
@@ -11,6 +11,7 @@ services:
     command: sh -c 'bin/rails db:create db:migrate && bundle exec puma'
     volumes:
       - ../../.:/app
+      - bundle_cache:/usr/local/bundle
     depends_on:
       - database
     environment:
@@ -22,3 +23,6 @@ services:
     image: postgres:11-alpine
     ports:
       - "5432:5432"
+
+volumes:
+  bundle_cache:

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.6'
+version: '3.7'
 
 services:
   web:
@@ -11,6 +11,7 @@ services:
     entrypoint: sh -c 'bin/rails db:create db:migrate && bundle exec puma'
     volumes:
       - ../../.:/app
+      - bundle_cache:/usr/local/bundle
     depends_on:
       - database
     environment:
@@ -22,3 +23,6 @@ services:
     image: postgres:11-alpine
     ports:
       - "5432:5432"
+
+  volumes:
+    bundle_cache:

--- a/docker/test/docker-compose.yml
+++ b/docker/test/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.6'
+version: '3.7'
 
 services:
   web:
@@ -11,6 +11,7 @@ services:
     command: sh -c 'bundle exec rake db:test:prepare && bundle exec rspec'
     volumes:
       - ../../.:/app
+      - bundle_cache:/usr/local/bundle
     depends_on:
       - database
     environment:
@@ -30,3 +31,5 @@ services:
     ports:
       - "4444:4444"
 
+volumes:
+  bundle_cache:


### PR DESCRIPTION
Since we're using the latest version of Ruby we should be able to use the bundled version of Bundler as well.

Related, I took the opportunity to include a lesson learned from some docker-compose work on Starlight. This adds a volume cache for gems that makes the development workflow w/ gems more like using your local machine.

#### Local Checklist
- [ ] Tests written and passing locally?
- [ ] Code style checked?
- [ ] QA-ed locally?
- [ ] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

@VivianChu  - please review
