### PR TITLE
rubocop: add rubocop-performance gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
-require: rubocop-rspec
+require:
+  - rubocop-performance
+  - rubocop-rspec
 
 AllCops:
+  TargetRubyVersion: 2.6
   DisplayCopNames: true
   Exclude:
     - 'vendor/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group :development, :test do
   gem 'pry-doc'
   gem 'rspec-rails'
   gem 'rubocop'
+  gem 'rubocop-performance'
   gem 'rubocop-rspec'
   gem 'selenium-webdriver'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,6 +234,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-performance (1.3.0)
+      rubocop (>= 0.68.0)
     rubocop-rspec (1.33.0)
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
@@ -344,6 +346,7 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rspec-rails
   rubocop
+  rubocop-performance
   rubocop-rspec
   sass-rails (~> 5.0)
   selenium-webdriver


### PR DESCRIPTION
It's being extracted out of rubocop to a dedicated gem

Getting ahead of the deprecation warnings.

#### Local Checklist
- [ ] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

@VivianChu  - please review
