### PR TITLE
Add okcomputer gem for health checks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'jbuilder', '~> 2.9'
 gem 'net-ldap', '~> 0.16.1'
 gem 'omniauth'
 gem 'omniauth-shibboleth'
+gem 'okcomputer'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,7 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
+    okcomputer (1.17.4)
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
@@ -339,6 +340,7 @@ DEPENDENCIES
   letter_opener_web (~> 1.0)
   listen (>= 3.0.5, < 3.2)
   net-ldap (~> 0.16.1)
+  okcomputer
   omniauth
   omniauth-shibboleth
   pagy (~> 3.5)

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Mount the health endpoint at /health
+# Review all health checks at /health/all
+OkComputer.mount_at = "health"
+


### PR DESCRIPTION
We will need this for deploying the application to kubernetes. For now,
we are mounting under '/health' to make it easy to setup the k8s
deployment configuration

Fixes #316 

#### Local Checklist
- [ ] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
- Adds `okcomputer` gem for adding a health check endpoint
- mounts the endpoint at `/health` (see: screenshots)

##### Why are we doing this? Any context of related work?
Setup for a Kubernetes deployment in the future

#### Screenshots
![image](https://user-images.githubusercontent.com/67506/67244308-4ec89b00-f40e-11e9-9b09-8867a8337b53.png)

![image](https://user-images.githubusercontent.com/67506/67244325-59833000-f40e-11e9-8351-602ed24303a7.png)

@ucsdlib/developers - please review
