### PR TITLE
Add DATABASE_COMMAND env var to entrypoint script

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -1,0 +1,3 @@
+APPS_H5_DB_HOST=database
+DATABASE_COMMAND=db:create db:migrate
+SELENIUM_URL=http://browser:4444/wd/hub/

--- a/README.md
+++ b/README.md
@@ -19,10 +19,19 @@ This app is using ENV-driven configuration options through
 
 To override environment variables set by `.env`, create a `.env.local` file: <https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use>.  We recommend adding the private variables into the `.env.local` file to avoid the risk of accidentally committing an updated file that contains the password.
 
+For the docker-compose setup, there is also a `.env.docker` file. This is used
+for environment variables that are required for the
+`docker/docker-entrypoint.sh` script that `dotenv` will not have made available
+yet. This allows the application to load the environment dotfile when needed
+(for development or test) while keeping these variables separate.
+
 ### Docker
 1. Install docker and docker-compose
 1. To spin up your environment, run `make up`
     - Run `make menu` to see all options
+
+> If you wish to persist your local development data across sessions, you can
+temporarily change the `DATABASE_COMMAND` to something like `db:migrate`
 
 #### Employee Data
 
@@ -41,7 +50,7 @@ Or you can invoke directly (development example):
 `docker-compose exec web rake db:seed`
 
 Note that you will need to either be on campus or using the VPN, as this
-accesses LDAP data from Active Directory. You will also need LDAP account info to load the seed data.  This info can be found in LastPass. You can put the following LDAP variables  `APPS_H5_LDAP_HOST, APPS_H5_LDAP_PORT, APPS_H5_LDAP_BASE, APPS_H5_LDAP_USERNAME, APPS_H5_LDAP_PW, APPS_H5_LDAP_GROUP` into `.env.local` file. 
+accesses LDAP data from Active Directory. You will also need LDAP account info to load the seed data.  This info can be found in LastPass. You can put the following LDAP variables  `APPS_H5_LDAP_HOST, APPS_H5_LDAP_PORT, APPS_H5_LDAP_BASE, APPS_H5_LDAP_USERNAME, APPS_H5_LDAP_PW, APPS_H5_LDAP_GROUP` into `.env.local` file.
 
 #### Testing
 1. For full test suite, run `make test`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,8 @@ services:
       target: development
     ports:
       - "3000:3000"
-    environment:
-      APPS_H5_DB_HOST: database
-      SELENIUM_URL: http://browser:4444/wd/hub/
+    env_file:
+      - ./.env.docker
     working_dir: /app
     volumes:
       - .:/app

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -27,11 +27,18 @@ else
     sleep 1
   done
 
-  bundle exec rake db:create db:schema:load
+  if [ -z "${DATABASE_COMMAND}" ]; then
+    echo "DATABASE_COMMAND is not supplied, skipping database rake tasks"
+  else
+    # Support env var option for database command(s)
+    for db_command in $DATABASE_COMMAND; do
+      bundle exec rake "$db_command"
+    done
 
-  if [ ! "$RAILS_ENV" = "test" ]; then
-    # populate LDAP employee data
-    bundle exec rake nightly:employees
+    if [ ! "$RAILS_ENV" = "test" ]; then
+      # populate LDAP employee data
+      bundle exec rake nightly:employees
+    fi
   fi
 fi
 


### PR DESCRIPTION
Fixes #326 

#### Local Checklist
- [ ] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [x] Configuration updated (if needed)?
- [x] Documentation updated (if needed)?

#### What does this PR do?
This will be required for the Helm/K8s deployment so that we can ensure
that deployments after the initial deploy always use `db:migrate`
instead of the `db:create db:schema:load`.

Add some initial documentation around this to the `README`

##### Why are we doing this? Any context of related work?
References #326 #301 

#### New ENV variables
`DATABASE_COMMAND` - Note this is not relevant for our existing deployments, since Capistrano is used to manage database rake tasks. So we don't need a PR to `env-variables` to add support for this.

@ucsdlib/developers - please review
