### PR TITLE
docker: fix bundler setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,18 +21,10 @@ ENV RACK_ENV=development
 ENV RAILS_LOG_TO_STDOUT=true
 ENV RAILS_ROOT=/app
 ENV LANG=C.UTF-8
-ENV GEM_HOME=/bundle
-ENV BUNDLE_PATH=$GEM_HOME
-ENV BUNDLE_APP_CONFIG=$BUNDLE_PATH
-ENV BUNDLE_BIN=$BUNDLE_PATH/bin
-ENV PATH=/app/bin:$BUNDLE_BIN:$PATH
 
 COPY Gemfile* /app/
-RUN gem update bundler \
-    && bundle install --jobs "$(nproc)" --retry 2 \
-    && rm -rf $BUNDLE_PATH/cache/*gem \
-    && find $BUNDLE_PATH/gems/ -name "*.c" -delete \
-    && find $BUNDLE_PATH/gems/ -name "*.o" -delete
+
+RUN gem update bundler && bundle install --jobs "$(nproc)" --retry 2
 
 COPY . /app
 
@@ -56,16 +48,11 @@ ENV RAILS_LOG_TO_STDOUT=true
 ENV RAILS_SERVE_STATIC_FILES=true
 ENV RAILS_ROOT=/app
 ENV LANG=C.UTF-8
-ENV GEM_HOME=/bundle
-ENV BUNDLE_PATH=$GEM_HOME
-ENV BUNDLE_APP_CONFIG=$BUNDLE_PATH
-ENV BUNDLE_BIN=$BUNDLE_PATH/bin
-ENV PATH=/app/bin:$BUNDLE_BIN:$PATH
 ENV SECRET_KEY_BASE=something
 ENV APPS_H5_DELIVERY_METHOD=letter_opener
 ENV APPS_H5_EMAIL_HOST=localhost:3000
 
-COPY --from=development /bundle /bundle
+COPY --from=development /usr/local/bundle /usr/local/bundle
 COPY --from=development /app ./
 
 RUN RAILS_ENV=production bundle exec rake assets:precompile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3.7'
 
 volumes:
-  bundles:
   database:
 
 services:
@@ -16,7 +15,6 @@ services:
     working_dir: /app
     volumes:
       - .:/app
-      - bundles:/bundle
     depends_on:
       - browser
       - database


### PR DESCRIPTION
Fixes: #361

Sometime between the 2.0.2 (locked) version of Bundler and the current
version (2.1.4) the method used in the Dockerfile for customized bundler
path setup ceased to function, causing errors when starting the Rails
application. This can probably be optimized again in the future, but for
now, make it work again.

#### Local Checklist
- [ ] Tests written and passing locally?
- [ ] Code style checked?
- [ ] QA-ed locally?
- [ ] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
- Remove custom, optimized setup for Bundler in `Dockerfile`
- Remove custom volume for bundler in docker-compose (this seems to get out of sync frequently and require deletion/rebuilds)

##### Why are we doing this? Any context of related work?
This is currently blocking work on #360 and #359 

@ucsdlib/developers - please review
