### PR TITLE
stats: make end_date inclusive for query

### DIFF
--- a/app/models/recognition.rb
+++ b/app/models/recognition.rb
@@ -18,8 +18,12 @@ class Recognition < ApplicationRecord
   scope :feed, -> { public_recognitions.first(15) }
 
   # A custom finder used for identifying records created between a given date range
+  # Note that the end date will be set to the end of the day, to allow for an inclusive search.
+  # @param start_date [String] start date for query of form YYYY-MM-DD
+  # @param end_date [String] end date for query of form YYYY-MM-DD
   def self.created_between(start_date, end_date)
-    where(created_at: start_date..end_date)
+    inclusive_end_date = Time.parse(end_date).end_of_day
+    where(created_at: start_date..inclusive_end_date)
   end
 
   # Generate an OptOutLink for this Recognition

--- a/spec/models/recognition_spec.rb
+++ b/spec/models/recognition_spec.rb
@@ -54,6 +54,15 @@ RSpec.describe Recognition, type: :model do
     it 'finds recognitions in a given date range' do
       expect(described_class.created_between('2018-01-01', '2018-12-31').map(&:description)).to eq(['in report'])
     end
+
+    it 'finds recognitions using an inclusive end date' do
+      recognition3 = FactoryBot.create(:recognition,
+                                       user: user,
+                                       created_at: Time.parse('2018-12-31 9:00'),
+                                       description: 'inclusive end date',
+                                       employee: employee)
+      expect(described_class.created_between('2018-01-01', '2018-12-31').map(&:description)).to eq(['in report', 'inclusive end date'])
+    end
   end
 
   describe '.feed' do


### PR DESCRIPTION
Fixes #359 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
The previous code took the start and end dates from the form, which came in the format of
YYYY-MM-DD, and then applies them to the `where` range query. This works
as expected for the start_date, but is problematic for the end_date
since a String date of the form YYYY-MM-DD will be turned into a
DateTime object which translates to the "beginning of that day".

This is confusing to administrators who expect Recognitions created on
the same date as their chosen end_date to be included in the results of
the statistics query. This change utilizes the Rails ActiveSupport
`end_of_day` method that gets mixed in to the `DateTime`.

##### Why are we doing this? Any context of related work?
References #issuenumber

#### Where should a reviewer start?
See the new test demonstrating a record created on the same day as the end date in the range query being included in the results.

#### Deployment Instructions

@ucsdlib/developers - please review
