### PR TITLE
Update the populate_from_ldap function to ignore employee with no mail attr

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,5 +32,5 @@ Metrics/LineLength:
   Max: 120
 
 Metrics/AbcSize:
-  Max: 18
+  Max: 20
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,5 +32,5 @@ Metrics/LineLength:
   Max: 120
 
 Metrics/AbcSize:
-  Max: 20
+  Max: 22
 

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -22,15 +22,17 @@ class Employee < ApplicationRecord
   end
 
   # Update a new, or existing, Employee with the employee info from LDAP
+  # rubocop:disable Metrics/LineLength, Style/IfUnlessModifier
   def self.update_employee_from_ldap(employee, employee_info)
     Rails.logger.tagged('employee', 'update') { Rails.logger.info "updating employee: #{employee.uid}" }
-    Rails.logger.info "No mail for employee: #{employee.uid}" && return unless employee_info.respond_to?(:mail)
+    Rails.logger.tagged('employee', 'update') { Rails.logger.info "No mail for employee: #{employee.uid}" } && return unless employee_info.respond_to?(:mail)
     employee.display_name = employee_info.displayname.first
     employee.email = employee_info.mail.first
     employee.manager = manager_cn_from_dn(employee_info.manager.first) if employee_info.respond_to?(:manager)
     employee.name = employee_display_name(employee_info)
     employee.save
   end
+  # rubocop:enable Metrics/LineLength, Style/IfUnlessModifier
 
   # Given an Net::LDAP::Entry extract and populate an Employee record
   # using the cn/uid as the unique key

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -24,6 +24,7 @@ class Employee < ApplicationRecord
   # Update a new, or existing, Employee with the employee info from LDAP
   def self.update_employee_from_ldap(employee, employee_info)
     Rails.logger.tagged('employee', 'update') { Rails.logger.info "updating employee: #{employee.uid}" }
+    Rails.logger.info "No mail for employee: #{employee.uid}" && return unless employee_info.respond_to?(:mail)
     employee.display_name = employee_info.displayname.first
     employee.email = employee_info.mail.first
     employee.manager = manager_cn_from_dn(employee_info.manager.first) if employee_info.respond_to?(:manager)

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -99,4 +99,26 @@ RSpec.describe Employee, type: :model do
       expect(Employee.first.display_name).to eq('Batman')
     end
   end
+  
+  describe '.populate_from_ldap for employee without a mail attribute' do
+    let(:entry1) { Net::LDAP::Entry.new('CN=aemployee,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU') }
+    before do
+      entry1['cn'] = 'aemployee'
+      entry1['displayName'] = ['Employee, A']
+      entry1['givenName'] = ['A']
+      entry1['sn'] = ['Employee']
+      entry1['manager'] = ['CN=bigboss1,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU']
+      entry1['whenChanged'] = ['20181127172427.0Z']
+    end
+
+    it 'should not handle updating Employee records', :aggregate_failures do
+      expect(Employee.count).to be_zero
+      # ensure the updated_at date is prior to our record to update
+      travel_to Date.new(2018, 10, 02) do
+        described_class.populate_from_ldap(entry1)
+      end
+
+      expect(Employee.count).to be_zero
+    end
+  end
 end


### PR DESCRIPTION
Fixes #360 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Check for missing mail attribute and do not process that record.

##### Why are we doing this? Any context of related work?
References #360 

#### Where should a reviewer start?

#### Manual testing steps?
run 'make up'

@ucsdlib/developers - please review
