### PR TITLE
Add slack notification to Recognition

### DIFF
--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'uri'
+require 'json'
+
+# The SlackNotifier service class provides a simple interface to send a Slack notification
+# to a pre-configured Slack App channel
+# It is expected that the Slack incoming webhook will be provided as an environment variables
+class SlackNotifier
+  TEMPLATE = 'Who-hoo! :tada: %s just received a High Five! :raised_hands: Check it out :point_right: %s'
+
+  # Entrypoint for calling classes such as Recognition
+  def self.call(*args)
+    new(*args).call
+  end
+
+  # @param employee_name [String] The display name for the recognized employee
+  # @param employee_rec_url [String] The full url to the Recognition
+  def initialize(employee_name:, employee_rec_url:)
+    @employee_name = employee_name
+    @employee_rec_url = employee_rec_url
+  end
+
+  # Primary instance method which will trigger a Slack notification
+  # rubocop:disable Metrics/MethodLength
+  def call
+    return unless Rails.application.config.send_slack_notifications
+
+    if slack_webhook_url.nil?
+      Rails.logger.tagged('slack', 'configuration') do
+        Rails.logger.info 'No SLACK_WEBHOOK_URL environment variable present'
+      end
+      return
+    end
+
+    Rails.logger.tagged('slack', 'notification') do
+      Rails.logger.info "Notifying Slack Channel for: #{@employee_name} with url #{@employee_rec_url} "
+    end
+    notify_slack
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  private
+
+  def notify_slack
+    uri = URI.parse(slack_webhook_url)
+
+    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      request = Net::HTTP::Post.new(uri, 'Content-Type' => 'application/json')
+      request.body = payload
+      response = http.request request # Net::HTTPResponse object
+      Rails.logger.tagged('slack', 'notification') { Rails.logger.info "Slack Channel Response: #{response.body}" }
+    end
+  end
+
+  def slack_webhook_url
+    @slack_webhook_url ||= ENV['SLACK_WEBHOOK_URL']
+  end
+
+  def payload
+    {
+      text: format(TEMPLATE, @employee_name, @employee_rec_url)
+    }.to_json
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,8 @@ module Hifive
       config.logger    = ActiveSupport::TaggedLogging.new(logger)
     end
 
+    config.send_slack_notifications = true
+
     # Setup email defaults for ActionMailer
     config.action_mailer.delivery_method = ENV.fetch('APPS_H5_DELIVERY_METHOD').to_sym
     config.action_mailer.default_url_options = { host: ENV.fetch('APPS_H5_EMAIL_HOST') }

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,10 @@
 # Load the Rails application.
 require_relative 'application'
 
+# Allow default_url_options to reuse action_mailer defaults
+# This is used in the Recognition#notify_slack method to allow access to using url_helpers such as recognition_url
+# without having to specify an explicit host parameter
+Hifive::Application.default_url_options = Hifive::Application.config.action_mailer.default_url_options
+
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,6 +1,10 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # We want to be extra careful not to send any notifications during test runs
+  # While it's unlikely that the SLACK_WEBHOOK_URL var will be set for a test environment, stuff happens.
+  config.send_slack_notifications = false
+
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped

--- a/spec/models/recognition_spec.rb
+++ b/spec/models/recognition_spec.rb
@@ -37,6 +37,28 @@ RSpec.describe Recognition, type: :model do
     end
   end
 
+  describe '#notify_slack' do
+    let(:employee) { FactoryBot.create(:employee) }
+    let(:user) { FactoryBot.create(:user) }
+    before(:each) do
+      Rails.application.config.send_slack_notifications = true
+    end
+
+    after(:each) do
+      Rails.application.config.send_slack_notifications = false
+    end
+
+    it 'calls the SlackNotifier service' do
+      allow_any_instance_of(SlackNotifier).to receive(:call).and_return(:nothing)
+      expect_any_instance_of(SlackNotifier).to receive(:call)
+      recognition = FactoryBot.create(:recognition,
+                                       user: user,
+                                       created_at: Time.parse('2018-12-31 9:00'),
+                                       description: 'employee is the greatest',
+                                       employee: employee)
+    end
+  end
+
   describe '.created_between' do
     let!(:recognition1) { FactoryBot.create(:recognition,
                                                  user: user,

--- a/spec/services/slack_notifier_spec.rb
+++ b/spec/services/slack_notifier_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe SlackNotifier, type: :service do
+  describe '#call' do
+    let!(:notifier) { described_class.new(employee_name: 'Jane Triton',
+                                          employee_rec_url: 'http://example.com/recognitions/1') }
+    # Temporarily use SlackNotifier in test environment
+    # This is set to false in config/environments/test
+    # to prevent accidentally spamming the Slack channel during testing
+    before(:each) do
+      Rails.application.config.send_slack_notifications = true
+    end
+
+    after(:each) do
+      Rails.application.config.send_slack_notifications = false
+    end
+
+    context 'with SLACK_WEBHOOK_URL set' do
+      before do
+        ENV["SLACK_WEBHOOK_URL"] = "http://slack-api.com"
+        # needed because we:
+        # - don't want to actually call the Slack service
+        # - call response.body in the logger
+        response_double = instance_double('Net::HTTPResponse', body: :ok)
+        allow_any_instance_of(Net::HTTP).to receive(:request).and_return(response_double)
+      end
+
+      after do
+        ENV["SLACK_WEBHOOK_URL"] = "http://slack-api.com"
+      end
+
+      it 'calls notify_slack' do
+        expect(notifier.call).to be_truthy
+      end
+    end
+
+    context 'without SLACK_WEBHOOK_URL set' do
+      before do
+        allow(ENV).to receive(:[]).with("SLACK_WEBHOOK_URL").and_return(nil)
+      end
+
+      it 'returns and does not post a notification' do
+        expect(notifier.call).to be(nil)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,7 @@ RSpec.configure do |config|
     # a real object. This is generally recommended, and will default to
     # `true` in RSpec 4.
     mocks.verify_partial_doubles = true
+    mocks.verify_doubled_constant_names = true
   end
 
   # This option will default to `:apply_to_host_groups` in RSpec 4 (and will


### PR DESCRIPTION
Fixes #365 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
This commit adds the following:
- A new service called `SlackNotifier` that is responsible for sending a
  formatted notification to a Slack channel via an incoming web hook.
This web hook url is expected to be provided via the `SLACK_WEBHOOK_URL`
env var
- An ActiveRecord callback named `notify_slack` in the `Recognition` model
  class that calls the `SlackNotifier` service
- Adds `default_url_options` to the Application in `config/environment.rb`, which inherit from the
  `action_mailer` settings so they are only set once. This is used in the
callback since the model does not have access to the host or dynamic
routing helpers by default. But, we need the Recognition url for the Slack message

##### Why are we doing this? Any context of related work?
References #365 

The High Five product owner would like more staff visibility for recognized staff and the application in general.

#### Where should a reviewer start?

* See some of the example submissions in the `#bot-testing` channel
* Look at the tests (and feedback on the tests welcome. I'm kind of happy with them, but if there's a better way to test the service and integration with the model I'm open to ideas.

#### New ENV variables
`SLACK_WEBHOOK_URL` - 

https://github.com/ucsdlib/ops-ansible-playbooks/pull/90
https://github.com/ucsdlib/ops-ansible-playbooks/pull/89

@ucsdlib/developers - please review
