### PR TITLE
Rename APPS_H5_EMAIL_HOST to APPS_H5_APP_HOST

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
       - image: circleci/ruby:2.6.5-node-browsers
       - image: circleci/postgres:11-alpine
     environment:
+      APPS_H5_APP_HOST: localhost
       APPS_H5_DB_HOST: localhost
       RAILS_ENV: test
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ ENV RAILS_ROOT=/app
 ENV LANG=C.UTF-8
 ENV SECRET_KEY_BASE=something
 ENV APPS_H5_DELIVERY_METHOD=letter_opener
-ENV APPS_H5_EMAIL_HOST=localhost:3000
+ENV APPS_H5_APP_HOST=localhost:3000
 
 COPY --from=development /usr/local/bundle /usr/local/bundle
 COPY --from=development /app ./

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,7 +42,7 @@ module Hifive
 
     # Setup email defaults for ActionMailer
     config.action_mailer.delivery_method = ENV.fetch('APPS_H5_DELIVERY_METHOD').to_sym
-    config.action_mailer.default_url_options = { host: ENV.fetch('APPS_H5_EMAIL_HOST') }
+    config.action_mailer.default_url_options = { host: ENV.fetch('APPS_H5_APP_HOST') }
 
     if ENV['APPS_H5_EMAIL_SMTP_HOST'].present? && ENV['APPS_H5_EMAIL_SMTP_PORT'].present?
       config.action_mailer.smtp_settings = { address: ENV.fetch('APPS_H5_EMAIL_SMTP_HOST'),

--- a/hifive/questions.yaml
+++ b/hifive/questions.yaml
@@ -30,12 +30,12 @@ questions:
     type: string
     required: true
     label: Path
-- variable: email.host
+- variable: image.host
   type: string
-  group: "Email"
+  group: "Application Host"
   default: highfive.local
-  label: "Email hostname URL (should match ingress hostname)"
-  description: "Email hostname URL (should match ingress hostname)"
+  label: "Application hostname URL (should match ingress hostname)"
+  description: "Application hostname URL (should match ingress hostname)"
 - variable: email.sender
   type: string
   group: "Email"

--- a/hifive/templates/deployment.yaml
+++ b/hifive/templates/deployment.yaml
@@ -36,8 +36,8 @@ spec:
               value: {{ .Values.email.bcc }}
             - name: "APPS_H5_DELIVERY_METHOD"
               value: {{ .Values.email.delivery_method }}
-            - name: "APPS_H5_EMAIL_HOST"
-              value: {{ .Values.email.host }}
+            - name: "APPS_H5_APP_HOST"
+              value: {{ .Values.image.host }}
             - name: "APPS_H5_SENDER"
               value: {{ .Values.email.sender }}
             - name: "APPS_H5_LDAP_BASE"

--- a/hifive/values.yaml
+++ b/hifive/values.yaml
@@ -5,6 +5,7 @@
 replicaCount: 1
 
 image:
+  host: highfive.local
   repository: ucsdlib/hifive
   name: hifive
   tag: stable


### PR DESCRIPTION
Fixes #373 

#### Local Checklist
- [ ] Tests written and passing locally?
- [ ] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Application: Rename in the config/application.rb file to match what will
now be in the env variables for the application

Helm Chart:

Previously, we were incorrectly assuming this was the email container
host. It is the application host, which the env var name now correctly
implies

##### Why are we doing this? Any context of related work?
References #373 

Related env vars PR: https://github.com/ucsdlib/ops-ansible-playbooks/pull/91

#### New ENV variables
Renames `APPS_H5_EMAIL_HOST` to `APPS_H5_APP_HOST`

#### Deployment Instructions

@ucsdlib/developers - please review
