### PR TITLE
Optional manager

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :development, :test do
   gem 'capybara'
   gem 'coveralls', '~> 0.8'
   gem 'factory_bot_rails'
+  gem 'pry-byebug'
   gem 'pry-rails'
   gem 'pry-doc'
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,9 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     pry-doc (1.0.0)
       pry (~> 0.11)
       yard (~> 0.9.11)
@@ -366,6 +369,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   pagy (~> 3.5)
   pg (>= 0.18, < 2.0)
+  pry-byebug
   pry-doc
   pry-rails
   puma (~> 4.3)

--- a/app/mailers/recognition_mailer.rb
+++ b/app/mailers/recognition_mailer.rb
@@ -16,7 +16,7 @@ class RecognitionMailer < ApplicationMailer
   def mail_to_group
     [@recognition.employee.email,
      manager_email(@recognition.employee.manager),
-     @recognition.user.email].join(',')
+     @recognition.user.email].compact.join(',')
   end
 
   def opt_out_key(id)

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -5,7 +5,7 @@
 class Employee < ApplicationRecord
   has_many :recognitions, dependent: :destroy
 
-  validates :uid, :email, :manager, :display_name, :name, presence: true
+  validates :uid, :email, :display_name, :name, presence: true
 
   # custom scopes
   scope :sort_by_name, -> { order(:display_name) }

--- a/db/migrate/20200226225209_allow_employees_without_managers.rb
+++ b/db/migrate/20200226225209_allow_employees_without_managers.rb
@@ -1,0 +1,5 @@
+class AllowEmployeesWithoutManagers < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :employees, :manager, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_30_213626) do
+ActiveRecord::Schema.define(version: 2020_02_26_225209) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2018_11_30_213626) do
   create_table "employees", force: :cascade do |t|
     t.string "uid", null: false
     t.string "name", null: false
-    t.string "manager", null: false
+    t.string "manager"
     t.string "email", null: false
     t.string "display_name", null: false
     t.datetime "created_at", null: false

--- a/spec/factories/employees.rb
+++ b/spec/factories/employees.rb
@@ -7,4 +7,12 @@ FactoryBot.define do
     sequence(:manager) { |n| "manager#{n}" }
     display_name { "MyString" }
   end
+
+  factory :employee_without_manager, class: "Employee" do
+    sequence(:uid) { |n| "employee#{n}" }
+    sequence(:email) { |n| "employee#{n}@ucsd.edu" }
+    name { "MyString" }
+    active { true }
+    display_name { "MyString" }
+  end
 end

--- a/spec/mailers/recognition_mailer_spec.rb
+++ b/spec/mailers/recognition_mailer_spec.rb
@@ -3,53 +3,81 @@
 require 'rails_helper'
 
 RSpec.describe RecognitionMailer do
-  let!(:manager) { FactoryBot.create(:employee) }
-  let(:recognition) { FactoryBot.build_stubbed(:recognition,
+
+  context 'without a valid manager' do
+    let(:user) { FactoryBot.build_stubbed(:user) }
+    let(:employee_without_manager) { FactoryBot.build_stubbed(:employee_without_manager) }
+    let(:employee_with_unknown_manager) { FactoryBot.build_stubbed(:employee_without_manager, manager: 'not-in-table') }
+    let(:recognition) { FactoryBot.build_stubbed(:recognition,
                                                  user: user,
                                                  created_at: Time.parse('2018-10-01'),
                                                  description: 'in report',
-                                                 employee: employee) }
-  let(:employee) { FactoryBot.create(:employee, manager: manager.uid) }
-  let(:user) { FactoryBot.build_stubbed(:user) }
-  let(:email) {RecognitionMailer.email(recognition)}
+                                                 employee: employee_without_manager) }
+    let(:recognition_unknown_manager) { FactoryBot.build_stubbed(:recognition,
+                                                                 user: user,
+                                                                 created_at: Time.parse('2018-10-01'),
+                                                                 description: 'in report',
+                                                                 employee: employee_with_unknown_manager) }
+    let(:email) { RecognitionMailer.email(recognition) }
+    let(:email_unknown_manager) { RecognitionMailer.email(recognition_unknown_manager) }
+    it 'renders the receiver list when manager is absent' do
+      expect(email.to).to eql([employee_without_manager.email, user.email])
+    end
 
-  it 'pretty prints the name of the user' do
-    user.full_name = 'Developer, The'
-    recognition = FactoryBot.build_stubbed(:recognition,
-                                            user: user,
-                                            created_at: Time.parse('2018-10-01'),
-                                            description: 'in report',
-                                            employee: employee)
-    email_name_test = RecognitionMailer.email(recognition)
-
-    expect(email_name_test.body.encoded).to match('The Developer')
+    it 'renders the receiver list when manager does not exist in Employee table' do
+      expect(email_unknown_manager.to).to eql([employee_with_unknown_manager.email, user.email])
+    end
   end
 
-  it 'renders the subject' do
-    expect(email.subject).to eql("You have been recognized!")
-  end
+  context 'with a valid manager' do
+    let!(:manager) { FactoryBot.create(:employee) }
+    let(:recognition) { FactoryBot.build_stubbed(:recognition,
+                                                   user: user,
+                                                   created_at: Time.parse('2018-10-01'),
+                                                   description: 'in report',
+                                                   employee: employee) }
+    let(:employee) { FactoryBot.create(:employee, manager: manager.uid) }
+    let(:user) { FactoryBot.build_stubbed(:user) }
+    let(:email) {RecognitionMailer.email(recognition)}
 
-  it 'renders the receiver email' do
-    expect(email.to).to eql([employee.email, manager.email, user.email])
-  end
+    it 'pretty prints the name of the user' do
+      user.full_name = 'Developer, The'
+      recognition = FactoryBot.build_stubbed(:recognition,
+                                              user: user,
+                                              created_at: Time.parse('2018-10-01'),
+                                              description: 'in report',
+                                              employee: employee)
+      email_name_test = RecognitionMailer.email(recognition)
 
-  it 'sends the recognizer a copy of the email' do
-    expect(email.to).to include(user.email)
-  end
+      expect(email_name_test.body.encoded).to match('The Developer')
+    end
 
-  it 'renders the sender email' do
-    expect(email.from).to eql(['developer@ucsd.edu'])
-  end
+    it 'renders the subject' do
+      expect(email.subject).to eql("You have been recognized!")
+    end
 
-  it 'assigns recognition name, library value, and description' do
-    expect(email.body.encoded).to match("Dear #{recognition.employee.name},")
-    expect(email.body.encoded).to match(LIBRARY_VALUES[recognition.library_value])
-    expect(email.body.encoded).to match(recognition.user.full_name)
-    expect(email.body.encoded).to match(recognition.description)
-  end
+    it 'renders the receiver email' do
+      expect(email.to).to eql([employee.email, manager.email, user.email])
+    end
 
-  it 'assigns recognition url' do
-    url = "/recognitions/#{recognition.id}"
-    expect(email.body.encoded).to match(url)
+    it 'sends the recognizer a copy of the email' do
+      expect(email.to).to include(user.email)
+    end
+
+    it 'renders the sender email' do
+      expect(email.from).to eql(['developer@ucsd.edu'])
+    end
+
+    it 'assigns recognition name, library value, and description' do
+      expect(email.body.encoded).to match("Dear #{recognition.employee.name},")
+      expect(email.body.encoded).to match(LIBRARY_VALUES[recognition.library_value])
+      expect(email.body.encoded).to match(recognition.user.full_name)
+      expect(email.body.encoded).to match(recognition.description)
+    end
+
+    it 'assigns recognition url' do
+      url = "/recognitions/#{recognition.id}"
+      expect(email.body.encoded).to match(url)
+    end
   end
 end

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -8,11 +8,15 @@ RSpec.describe Employee, type: :model do
     end
   end
 
-
   context 'valid recognition' do
     let(:employee) { FactoryBot.build_stubbed(:employee) }
+    let(:employee_without_manager) { FactoryBot.build_stubbed(:employee_without_manager) }
     it "persists with required attributes" do
       expect(employee).to be_valid
+    end
+
+    it "persists without requiring a manager" do
+      expect(employee_without_manager).to be_valid
     end
   end
 
@@ -99,7 +103,7 @@ RSpec.describe Employee, type: :model do
       expect(Employee.first.display_name).to eq('Batman')
     end
   end
-  
+
   describe '.populate_from_ldap for employee without a mail attribute' do
     let(:entry1) { Net::LDAP::Entry.new('CN=aemployee,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU') }
     before do


### PR DESCRIPTION
References #369 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [x] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
- Adds missing `pry-byebug` gem for debugging
- Allow `Employee` records to optionally have a `manager` instead of requiring it.

We have three scenarios that have been identified that could cause an
`Employee`, that is valid as far as the application is concerned, to not
have a `manager` attribute in LDAP

1. The `ldap_sync` script simply has not run and updated the employee record. This could happen for new employees or employees who change jobs in the library
2. The employee has a dual-assignment, and their AD record is not owned and managed by the Library
3. The employee has a dual-assignment, and their AD record is owned and managed by the Library, but their manager does not work for the Library

##### Why are we doing this? Any context of related work?
References #369 

The application needs to be made a bit more flexible to accommodate some edge cases. Shocking, we know.

#### Where should a reviewer start?
Please take a hard look at this. It's a fairly large change

- Look at the migration and resulting `db/schema`
- Look at the new test coverage. I tried to cover the scenarios I could think of. Am I missing anything?
- Other concerns or additional edge cases I haven't covered here?

#### Database changes
Change the `manager` column in the `employees` table to allow `NULL` values.

@ucsdlib/developers - please review
