### PR TITLE
Update ldap query to use different security group

### DIFF
--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -12,10 +12,10 @@ class Employee < ApplicationRecord
   scope :active_employees, -> { where(active: true).sort_by_name }
 
   # Given an Net::LDAP::Entry extract and populate an Employee record
-  # using the cn/uid as the unique key
+  # using the SAMAccountName/uid as the unique key
   # @param [Net::LDAP::Entry] employee_info
   def self.populate_from_ldap(employee_info)
-    e = find_or_initialize_by(uid: employee_info.cn.first)
+    e = find_or_initialize_by(uid: employee_info.SAMAccountName.first)
     return unless needs_update?(e, String(employee_info.whenChanged.first))
 
     update_employee_from_ldap(e, employee_info)
@@ -35,7 +35,7 @@ class Employee < ApplicationRecord
   # rubocop:enable Layout/LineLength
 
   # Given an Net::LDAP::Entry extract and populate an Employee record
-  # using the cn/uid as the unique key
+  # using the SAMAccountName/uid as the unique key
   # @param [Net::LDAP::Entry] employee_info
   def self.employee_display_name(employee_info)
     "#{employee_info.givenName.first} #{employee_info.sn.first}"

--- a/app/services/ldap/filters.rb
+++ b/app/services/ldap/filters.rb
@@ -5,19 +5,17 @@ module Ldap
   class Filters
     # Only show current library staff, excluding students
     # @return [NET::LDAP::Filter] for employees query
+    # rubocop:disable Metrics/LineLength
     def self.employees
-      employees_only = Net::LDAP::Filter.pres('EmployeeID')
-      staff = Net::LDAP::Filter.eq('ObjectCategory', 'person')
-      users = Net::LDAP::Filter.eq('ObjectClass', 'user')
-      no_lib_accounts = Net::LDAP::Filter.ne('sAMAccountName', 'lib-*')
-      employees_only & staff & users & no_lib_accounts
+      Net::LDAP::Filter::FilterParser.parse('(&(objectCategory=user)(memberOf:1.2.840.113556.1.4.1941:=CN=All Library Staff,OU=Groups,OU=University Library,DC=AD,DC=UCSD,DC=EDU))')
     end
+    # rubocop:enable Metrics/LineLength
 
     # Filters for checking if a given user is a library employee
     # @param uid [String] the user id to check. e.g. 'drseuss'
     # @return [NET::LDAP::Filter] for employees query
     def self.library_staff_member(uid)
-      Net::LDAP::Filter.eq('CN', uid) & employees
+      Net::LDAP::Filter.eq('SAMAccountName', uid) & employees
     end
 
     # Only query against the given uid as a member of the hifive ldap group

--- a/app/services/ldap/queries.rb
+++ b/app/services/ldap/queries.rb
@@ -42,10 +42,10 @@ module Ldap
       ldap_connection.search(
         filter: Ldap::Filters.employees,
         return_result: false,
-        attributes: %w[DisplayName CN mail manager givenName sn whenChanged]
+        attributes: %w[DisplayName CN mail manager givenName sn whenChanged SAMAccountName]
       ) do |employee|
         Employee.populate_from_ldap(employee)
-        current_employees << employee.cn.first
+        current_employees << employee.SAMAccountName.first
       end
       Employee.update_status_for_all(current_employees)
       validate_ldap_response
@@ -53,7 +53,7 @@ module Ldap
     end
     # rubocop:enable Metrics/MethodLength
 
-    # Given a UID/CN determine whether a user is a library staff member using #employees filter
+    # Given a UID/SAMAccountName determine whether a user is a library staff member using #employees filter
     # @param uid [String] the user id to check. e.g. 'drseuss'
     # @return [String] the original uid if valid library staff
     def self.library_staff(uid)
@@ -61,15 +61,15 @@ module Ldap
 
       ldap_connection.search(
         filter: Ldap::Filters.library_staff_member(uid),
-        attributes: %w[CN],
+        attributes: %w[SAMAccountName],
         return_result: false
-      ) { |item| result = item.cn.first }
+      ) { |item| result = item.SAMAccountName.first }
 
       validate_ldap_response
       result
     end
 
-    # Given a UID/CN determine whether a user is in the hifive admin group
+    # Given a UID/SAMAccountName determine whether a user is in the hifive admin group
     # @param uid [String] the user id to check. e.g. 'drseuss'
     # @return [String] the original uid, assuming it is in the hifive group
     def self.hifive_group(uid)
@@ -77,9 +77,9 @@ module Ldap
 
       ldap_connection.search(
         filter: Ldap::Filters.hifive_admin(uid),
-        attributes: %w[CN],
+        attributes: %w[SAMAccountName],
         return_result: false
-      ) { |item| result = item.cn.first }
+      ) { |item| result = item.SAMAccountName.first }
 
       validate_ldap_response
       result

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Employee, type: :model do
       entry['mail'] = ['aemployee@ucsd.edu']
       entry['manager'] = ['CN=bigboss1,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU']
       entry['whenChanged'] = ['20181127172427.0Z']
+      entry['SAMAccountName'] = 'aemployee'
     end
 
     it 'returns true with a new record' do
@@ -87,6 +88,7 @@ RSpec.describe Employee, type: :model do
       entry1['mail'] = ['aemployee@ucsd.edu']
       entry1['manager'] = ['CN=bigboss1,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU']
       entry1['whenChanged'] = ['20181127172427.0Z']
+      entry1['SAMAccountName'] = 'aemployee'
     end
 
     it 'should handle updating Employee records', :aggregate_failures do
@@ -113,6 +115,7 @@ RSpec.describe Employee, type: :model do
       entry1['sn'] = ['Employee']
       entry1['manager'] = ['CN=bigboss1,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU']
       entry1['whenChanged'] = ['20181127172427.0Z']
+      entry1['SAMAccountName'] = 'aemployee'
     end
 
     it 'should not handle updating Employee records', :aggregate_failures do

--- a/spec/services/ldap/filters_spec.rb
+++ b/spec/services/ldap/filters_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 RSpec.describe Ldap::Filters, type: :service do
   describe '.employees' do
     it 'returns an LDAP filter for all Library employees' do
-      expect(described_class.employees.to_s).to eq('(&(&(&(EmployeeID=*)(ObjectCategory=person))(ObjectClass=user))(!(sAMAccountName=lib-*)))')
+      expect(described_class.employees.to_s).to eq('(&(objectCategory=user)(memberOf:1.2.840.113556.1.4.1941:=CN=All Library Staff,OU=Groups,OU=University Library,DC=AD,DC=UCSD,DC=EDU))')
     end
   end
 
   describe '.hifive_admin' do
     it 'returns an LDAP filter to check admin membership' do
-      expect(described_class.hifive_admin('drseuss').to_s).to eq('(&(&(CN=drseuss)(&(&(&(EmployeeID=*)(ObjectCategory=person))(ObjectClass=user))(!(sAMAccountName=lib-*))))(memberof=memberof=CN=lib-test))')
+      expect(described_class.hifive_admin('drseuss').to_s).to eq('(&(&(SAMAccountName=drseuss)(&(objectCategory=user)(memberOf:1.2.840.113556.1.4.1941:=CN=All Library Staff,OU=Groups,OU=University Library,DC=AD,DC=UCSD,DC=EDU)))(memberof=memberof=CN=lib-test))')
     end
   end
 end

--- a/spec/services/ldap/queries_spec.rb
+++ b/spec/services/ldap/queries_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Ldap::Queries, type: :service do
   describe '.library_staff' do
     before do
       entry1 = Net::LDAP::Entry.new('CN=drseuss,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU')
-      entry1['cn'] = 'drseuss'
+      entry1['SAMAccountName'] = 'drseuss'
       entry2 = Net::LDAP::Entry.new('CN=nonadmin,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU')
-      entry2['cn'] = ''
+      entry2['SAMAccountName'] = ''
       mock_ldap_validation
       allow(mock_ldap_connection).to receive(:search).and_yield(entry1).and_yield(entry2)
     end
@@ -15,7 +15,7 @@ RSpec.describe Ldap::Queries, type: :service do
       expect(described_class.library_staff('nonadmin')).to eq('')
     end
 
-    it 'returns the cn for the given user with a match' do
+    it 'returns the SAMAccountName for the given user with a match' do
       expect(described_class.library_staff('drseuss')).to eq('')
     end
   end
@@ -23,9 +23,9 @@ RSpec.describe Ldap::Queries, type: :service do
   describe '.hifive_group' do
     before do
       entry1 = Net::LDAP::Entry.new('CN=drseuss,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU')
-      entry1['cn'] = 'drseuss'
+      entry1['SAMAccountName'] = 'drseuss'
       entry2 = Net::LDAP::Entry.new('CN=nonadmin,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU')
-      entry2['cn'] = ''
+      entry2['SAMAccountName'] = ''
       mock_ldap_validation
       allow(mock_ldap_connection).to receive(:search).and_yield(entry1).and_yield(entry2)
     end
@@ -34,7 +34,7 @@ RSpec.describe Ldap::Queries, type: :service do
       expect(described_class.hifive_group('nonadmin')).to eq('')
     end
 
-    it 'returns the cn for the given user with a match' do
+    it 'returns the SAMAccountName for the given user with a match' do
       expect(described_class.hifive_group('drseuss')).to eq('')
     end
   end
@@ -49,6 +49,7 @@ RSpec.describe Ldap::Queries, type: :service do
       entry1['mail'] = ['aemployee@ucsd.edu']
       entry1['manager'] = ['CN=bigboss1,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU']
       entry1['whenChanged'] = ['20181130172427.0Z']
+      entry1['SAMAccountName'] = 'aemployee'
       entry2 = Net::LDAP::Entry.new('CN=zbestemployee,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU')
       entry2['cn'] = 'zbestemployee'
       entry2['displayName'] = ["Zbestemployee, The"]
@@ -57,6 +58,7 @@ RSpec.describe Ldap::Queries, type: :service do
       entry2['mail'] = ['zbestemployee@ucsd.edu']
       entry2['manager'] = ['CN=bigboss2,OU=Users,OU=University Library,DC=AD,DC=UCSD,DC=EDU']
       entry2['whenChanged'] = ['20181130172427.0Z']
+      entry2['SAMAccountName'] = 'zbestemployee'
       mock_ldap_validation
       allow(mock_ldap_connection).to receive(:search).and_yield(entry1).and_yield(entry2)
     end


### PR DESCRIPTION
Fixes #369 

#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Update ldap query to use different security group and use samaccountname instead of CN for uid.

##### Why are we doing this? Any context of related work?
References #369 

#### Where should a reviewer start?

#### Manual testing steps?
It's deployed to staging.

#### Screenshots
![newRecoginition](https://user-images.githubusercontent.com/1864660/75491278-8e7a3300-596a-11ea-81ed-afd88a87b422.png)

---


#### Deployment Instructions

@ucsdlib/developers - please review
