### PR TITLE
Group capistrano gems for deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,18 +28,6 @@ gem 'net-ldap', '~> 0.16.2'
 gem 'omniauth'
 gem 'omniauth-google-oauth2'
 gem 'okcomputer'
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-# Use ActiveStorage variant
-# gem 'mini_magick', '~> 4.8'
-
-# Use Capistrano for deployment
-gem 'capistrano', '~> 3.12.0'
-gem 'capistrano-bundler', '1.6.0'
-gem 'capistrano-rails', '~> 1.4.0'
-gem 'capistrano-rbenv', '~> 2.1.4'
-
 # Simple Form, Bootstrap and friends
 gem 'bootstrap', '~> 4.3.1'
 gem 'bootstrap-datepicker-rails'
@@ -52,6 +40,14 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'pagy', '~> 3.5'
 gem 'whenever', require: false
 gem 'listen', '>= 3.0.5', '< 3.3'
+
+# Use Capistrano for deployment
+group :deploy do
+  gem 'capistrano', '~> 3.12.0'
+  gem 'capistrano-bundler', '1.6.0'
+  gem 'capistrano-rails', '~> 1.4.0'
+  gem 'capistrano-rbenv', '~> 2.1.4'
+end
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console


### PR DESCRIPTION
#### What does this PR do?
This allows the application to leverage the `BUNDLE_WITHOUT` and
`BUNDLE_WITH` environment variables for usage in GitLab's CI/CD system.

I wanted to make sure this change wouldn't cause issues using our current heaven/deploybot setup. A test deploy of this branch to `staging` seems to indicate no problems. This was expected as heaven manages gems used for deployment on its own, but this was a helpful sanity check.

https://gist.github.com/VivianChu/2e1edd733335ddf4c1c6ac41c1365c1d

##### Why are we doing this? Any context of related work?
Prepping for CI/CD on Gitlab

@ucsdlib/developers - please review
