### PR TITLE
Slack name display update

### DIFF
--- a/app/controllers/recognitions_controller.rb
+++ b/app/controllers/recognitions_controller.rb
@@ -41,7 +41,7 @@ class RecognitionsController < ApplicationController
 
   # POST /recognitions
   # POST /recognitions.json
-  # rubocop:disable Layout/MethodLength
+  # rubocop:disable Metrics/MethodLength
   def create
     @recognition = Recognition.new(recognition_params)
     @recognition.user = current_user
@@ -55,7 +55,7 @@ class RecognitionsController < ApplicationController
       end
     end
   end
-  # rubocop:enable Layout/MethodLength
+  # rubocop:enable Metrics/MethodLength
 
   # PATCH/PUT /recognitions/1
   # PATCH/PUT /recognitions/1.json

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -39,10 +39,10 @@ class SessionsController < ApplicationController
   def destroy
     destroy_user_session
 
-    # rubocop:disable Metrics/LineLength
+    # rubocop:disable Layout/LineLength
     redirect_to logout_url,
                 notice: 'You have been logged out of High Five! To log out of all Single Sign-On applications, close your browser.'
-    # rubocop:enable Metrics/LineLength
+    # rubocop:enable Layout/LineLength
   end
 
   private

--- a/app/helpers/recognitions_helper.rb
+++ b/app/helpers/recognitions_helper.rb
@@ -22,8 +22,7 @@ module RecognitionsHelper
   # Reformat "Lastname, Firstanme" to "Firstname Lastname" (show view)
   #---
   def pretty_name(name)
-    exceptions = ['John H. Robinson, IV']
-    if name.count(',') == 1 && !exceptions.include?(name)
+    if name.count(',') == 1
       name = name.split(',', 2)
       name = name[1] + ' ' + name[0]
     end

--- a/app/helpers/recognitions_helper.rb
+++ b/app/helpers/recognitions_helper.rb
@@ -24,7 +24,7 @@ module RecognitionsHelper
   def pretty_name(name)
     if name.count(',') == 1
       name = name.split(',', 2)
-      name = name[1] + ' ' + name[0]
+      name = "#{name[1]} #{name[0]}".strip
     end
     name
   end

--- a/app/services/ldap/filters.rb
+++ b/app/services/ldap/filters.rb
@@ -5,11 +5,11 @@ module Ldap
   class Filters
     # Only show current library staff, excluding students
     # @return [NET::LDAP::Filter] for employees query
-    # rubocop:disable Metrics/LineLength
+    # rubocop:disable Layout/LineLength
     def self.employees
       Net::LDAP::Filter::FilterParser.parse('(&(objectCategory=user)(memberOf:1.2.840.113556.1.4.1941:=CN=All Library Staff,OU=Groups,OU=University Library,DC=AD,DC=UCSD,DC=EDU))')
     end
-    # rubocop:enable Metrics/LineLength
+    # rubocop:enable Layout/LineLength
 
     # Filters for checking if a given user is a library employee
     # @param uid [String] the user id to check. e.g. 'drseuss'

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -8,6 +8,8 @@ require 'json'
 # to a pre-configured Slack App channel
 # It is expected that the Slack incoming webhook will be provided as an environment variables
 class SlackNotifier
+  include RecognitionsHelper
+  attr_reader :employee_name, :employee_rec_url
   TEMPLATE = 'Woo-hoo! :tada: %s just received a High Five! :raised_hands: Check it out :point_right: %s'
 
   # Entrypoint for calling classes such as Recognition
@@ -18,7 +20,7 @@ class SlackNotifier
   # @param employee_name [String] The display name for the recognized employee
   # @param employee_rec_url [String] The full url to the Recognition
   def initialize(employee_name:, employee_rec_url:)
-    @employee_name = employee_name
+    @employee_name = pretty_name(employee_name)
     @employee_rec_url = employee_rec_url
   end
 
@@ -35,7 +37,7 @@ class SlackNotifier
     end
 
     Rails.logger.tagged('slack', 'notification') do
-      Rails.logger.info "Notifying Slack Channel for: #{@employee_name} with url #{@employee_rec_url} "
+      Rails.logger.info "Notifying Slack Channel for: #{employee_name} with url #{employee_rec_url} "
     end
     notify_slack
   end
@@ -60,7 +62,7 @@ class SlackNotifier
 
   def payload
     {
-      text: format(TEMPLATE, @employee_name, @employee_rec_url)
+      text: format(TEMPLATE, employee_name, employee_rec_url)
     }.to_json
   end
 end

--- a/spec/services/slack_notifier_spec.rb
+++ b/spec/services/slack_notifier_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SlackNotifier, type: :service do
   describe '#call' do
-    let!(:notifier) { described_class.new(employee_name: 'Jane Triton',
+    let!(:notifier) { described_class.new(employee_name: 'Triton, Jane',
                                           employee_rec_url: 'http://example.com/recognitions/1') }
     # Temporarily use SlackNotifier in test environment
     # This is set to false in config/environments/test
@@ -13,6 +13,10 @@ RSpec.describe SlackNotifier, type: :service do
 
     after(:each) do
       Rails.application.config.send_slack_notifications = false
+    end
+
+    it 'prints first name then last when name is of form lastname, firstname' do
+      expect(notifier.employee_name).to eq('Jane Triton')
     end
 
     context 'with SLACK_WEBHOOK_URL set' do


### PR DESCRIPTION
#### Local Checklist
- [x] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
- Removes John and the related exceptions code from the `pretty_name` method
- Include and leverage the `pretty_name` method from the
  `RecognitionsHelper` module in the `SlackNotifier` class
- Update the `pretty_name` method to create an interpolated string, and
  also ensure that any leading and trailing whitespace are omitted via
`strip`
- Add test to demonstrate the new name display working for the `SlackNotifier`
- Makes a few additional rubocop-related updates due to namespace moves (:man_shrugging: )

#### Screenshots
![image](https://user-images.githubusercontent.com/67506/75905317-80f4fb00-5df9-11ea-9e31-e107ba512470.png)

@ucsdlib/developers - please review
