### PR TITLE
Use https protocol for URLs in staging/prod

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,10 +1,10 @@
 # Load the Rails application.
 require_relative 'application'
 
+# Initialize the Rails application.
+Rails.application.initialize!
+
 # Allow default_url_options to reuse action_mailer defaults
 # This is used in the Recognition#notify_slack method to allow access to using url_helpers such as recognition_url
 # without having to specify an explicit host parameter
-Hifive::Application.default_url_options = Hifive::Application.config.action_mailer.default_url_options
-
-# Initialize the Rails application.
-Rails.application.initialize!
+Hifive::Application.default_url_options = Rails.application.config.action_mailer.default_url_options

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,6 +69,9 @@ Rails.application.configure do
 
   config.action_mailer.raise_delivery_errors = true
 
+  config.action_mailer.default_url_options = { host: ENV.fetch('APPS_H5_APP_HOST'),
+                                               protocol: 'https://' }
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -69,6 +69,11 @@ Rails.application.configure do
 
   config.action_mailer.raise_delivery_errors = true
 
+  config.action_mailer.default_url_options = { host: ENV.fetch('APPS_H5_APP_HOST'),
+                                               protocol: 'https://' }
+
+  # Print deprecation notices to the Rails logger.
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
Fixes #388 

#### Local Checklist
- [ ] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
- We run our staging/production environments in https mode, let's have
  our URLs reflect that despite the fact that we compensate for it at
the http server level
- Use the newer syntax for having the `default_url_options` be in sync
  between action_mailer and the application (Rails 5.2+)

##### Why are we doing this? Any context of related work?
References #388 - We don't want `http` links going out to folks since the app itself will always be running in an `https` context.

#### Screenshots
Email example:
![image](https://user-images.githubusercontent.com/67506/76235871-f7726e00-61e8-11ea-8f95-6f679d17731b.png)

Slack example:
![image](https://user-images.githubusercontent.com/67506/76235900-035e3000-61e9-11ea-9838-c31cd58e7858.png)

@ucsdlib/developers - please review
